### PR TITLE
HCLOUD-1371_rework-getAuditLogs-with-filters-as-query_strings-to-work-as-searchAuditLogs-and-post-filters-like-we-have-in-all-other-endpoints_Darius-Weiberg

### DIFF
--- a/src/lib/helper/searchFilter.ts
+++ b/src/lib/helper/searchFilter.ts
@@ -10,14 +10,14 @@ import {
 class SearchFilterDTO {
     private type: SearchFilterType;
     private key: string;
-    private value: string | number | boolean | string[];
     private comparator: SearchFilterComparatorString | SearchFilterComparatorNumber | SearchFilterComparatorDate | SearchFilterComparatorBoolean;
+    private value: string | number | boolean | string[];
 
     constructor(searchFilter: SearchFilter) {
         this.type = searchFilter.type;
         this.key = searchFilter.key;
-        this.value = (searchFilter as any).value;
         this.comparator = (searchFilter as any).comparator;
+        this.value = (searchFilter as any).value;
     }
 }
 


### PR DESCRIPTION
Replace getAuditLogs with searchAuditLogs