### PR TITLE
HCLOUD-1418_remove-hcloudgetNats-from-hcloud-file-and-simply-use-hcloudNats_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.33
+
+- Remove hcloud.getNatsService()
+
 ## 0.0.32
 
 - Add missing endpoints related to stream-execution-logs

--- a/src/lib/hcloud.ts
+++ b/src/lib/hcloud.ts
@@ -72,8 +72,4 @@ export default class hcloud {
     getCorrelationId(): string | undefined {
         return this.axios.defaults.headers.common["X-Hcloud-Correlation-ID"]?.toString();
     }
-
-    getNatsService(): NatsService {
-        return this.Nats;
-    }
 }


### PR DESCRIPTION
Remove getNatsService() from hcloud.ts