### PR TITLE
Consolidate interface definitions

### DIFF
--- a/src/lib/interfaces/fuse/space/cronjob/Cronjob.ts
+++ b/src/lib/interfaces/fuse/space/cronjob/Cronjob.ts
@@ -22,15 +22,5 @@ export interface Cronjob {
     nextExecution?: number;
 }
 
-export interface CreateCronjob {
-    name: string;
-    expression: string;
-    targetUrl: string;
-    httpMethod: HttpMethod;
-    acceptInvalidSSL?: boolean;
-    timezone?: string;
-    description?: string;
-    headers?: Header[];
-    body?: string;
-    enabled?: boolean;
-}
+export type CreateCronjob = Pick<Cronjob, "name" | "expression" | "targetUrl" | "httpMethod" | "headers" | "body" | "enabled" | "description"> &
+    Partial<Pick<Cronjob, "acceptInvalidSSL" | "timezone">>;

--- a/src/lib/interfaces/fuse/space/cronjob/CronjobLog.ts
+++ b/src/lib/interfaces/fuse/space/cronjob/CronjobLog.ts
@@ -2,12 +2,6 @@ import { ReducedOrganization } from "../../../idp/organization";
 import { ReducedUser } from "../../../idp/user";
 import { Header } from "../../../global";
 
-export interface CronjobLogCreation {
-    statusCode: number;
-    headers?: Header[];
-    body: string;
-}
-
 export interface CronjobLogDto {
     _id: string;
     cronjobId: string;
@@ -21,3 +15,5 @@ export interface CronjobLogDto {
     createDate: number;
     modifyDate: number;
 }
+
+export type CronjobLogCreation = Pick<CronjobLogDto, "statusCode" | "headers" | "body">;

--- a/src/lib/interfaces/fuse/space/index.ts
+++ b/src/lib/interfaces/fuse/space/index.ts
@@ -1,10 +1,4 @@
-import { Space, SpacePermission } from "../../global";
+import { Space } from "../../global";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FuseSpace extends Space {}
-
-export interface UpdateFuseSpace {
-    name?: string;
-    permissions?: SpacePermission[];
-    organizationId?: string;
-}

--- a/src/lib/interfaces/global/Space.ts
+++ b/src/lib/interfaces/global/Space.ts
@@ -1,6 +1,8 @@
 import { ReducedOrganization } from "../idp/organization";
 import { ReducedUser } from "../idp/user";
 
+type ExtendWith<T1, T2> = T1 & T2;
+
 export enum SpacePermission {
     NONE = "NONE",
     READ = "READ",
@@ -25,7 +27,7 @@ export interface Space {
     organization: ReducedOrganization;
     avatarUrl: string;
     creator: ReducedUser;
-    permissions: (SpaceEntityPermission & { name: string })[];
+    permissions: ExtendWith<SpaceEntityPermission, { name: string }>[];
     createDate: number;
     modifyDate: number;
 }

--- a/src/lib/interfaces/high5/space/event/stream/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/index.ts
@@ -62,6 +62,7 @@ export interface StreamExecutionPayload {
 export interface StreamExecutionRequest {
     payload: StreamExecutionPayload;
     target: string;
+    dry: boolean;
 }
 
 export interface EventExecutionRequest {

--- a/src/lib/interfaces/high5/space/webhook/index.ts
+++ b/src/lib/interfaces/high5/space/webhook/index.ts
@@ -48,25 +48,12 @@ export interface Webhook {
     modifyDate: number;
 }
 
-export interface WebhookCreation {
-    name: string;
-    target: string;
-    type: WebhookType;
-    sub: EventWebhook | SpaceWebhook | FrameIoWebhook;
-    webhookEncryptionSettings?: WebhookEncryptionSettings;
-    securityHeaders?: SecurityHeader[];
-}
+export type WebhookCreation = Pick<Webhook, "name" | "target" | "type" | "sub" | "webhookEncryptionSettings" | "securityHeaders">;
 
-export interface WebhookUpdate {
-    name?: string;
-    target?: string;
-    type?: WebhookType;
-    sub?: EventWebhook | SpaceWebhook | FrameIoWebhook;
-    webhookEncryptionSettings?: WebhookEncryptionSettings;
+export type WebhookUpdate = Partial<WebhookCreation> & {
     deleteWebhookEncryptionSettings?: boolean;
-    securityHeaders?: SecurityHeader[];
     deleteSecurityHeaders?: boolean;
-}
+};
 
 export interface WebhookLog {
     _id: string;

--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Refers to a GitHub release.
+ */
 export interface WaveRelease {
     releaseTag: string;
     browserUrl: string;
@@ -10,6 +13,13 @@ export interface WaveEngine {
     content: string;
 }
 
+/**
+ * Refers to an asset (file) within a GitHub release.
+ *
+ * A WaveEngineReleaseAsset that belong to a certain WaveRelease will
+ * share the same releaseTag and latest value, but will have a different
+ * browserUrl since the URL will refer to the specific asset.
+ */
 export interface WaveEngineReleaseAsset {
     releaseTag: string;
     browserUrl: string;

--- a/src/lib/interfaces/idp/organization/index.ts
+++ b/src/lib/interfaces/idp/organization/index.ts
@@ -20,16 +20,7 @@ export interface Organization {
     modifyDate: number;
 }
 
-export interface OrganizationWithPermission {
-    _id: string;
-    name: string;
-    isUserOrganization: boolean;
-    membersCount: number;
-    company: string;
-    avatarUrl: string;
-    creator: ReducedUser;
-    createDate: number;
-    modifyDate: number;
+export interface OrganizationWithPermission extends Organization {
     permission: OrganizationPermission;
 }
 
@@ -37,8 +28,4 @@ export interface OrganizationWithPermissionAndTeams extends OrganizationWithPerm
     teams: ReducedTeam[];
 }
 
-export interface ReducedOrganization {
-    _id: string;
-    name: string;
-    avatarUrl: string;
-}
+export type ReducedOrganization = Pick<Organization, "_id" | "name" | "avatarUrl">;

--- a/src/lib/interfaces/idp/organization/settings/domain/saml/index.ts
+++ b/src/lib/interfaces/idp/organization/settings/domain/saml/index.ts
@@ -1,11 +1,3 @@
-export interface FullSAMLProvider {
-    domainName: string;
-    ssoLoginURL: string;
-    ssoLogoutURL: string;
-    certificates: string[];
-    allowUnencryptedAssertion: boolean;
-}
-
 export interface SAMLProvider {
     ssoLoginURL: string;
     ssoLogoutURL: string;
@@ -13,9 +5,8 @@ export interface SAMLProvider {
     allowUnencryptedAssertion: boolean;
 }
 
-export interface SAMLProviderCreateDto {
-    ssoLoginURL: string;
-    ssoLogoutURL: string;
-    certificates: string[];
-    allowUnencryptedAssertion?: boolean;
+export interface FullSAMLProvider extends SAMLProvider {
+    domainName: string;
 }
+
+export type SAMLProviderCreateDto = Omit<SAMLProvider, "allowUnencryptedAssertion"> & Partial<Pick<SAMLProvider, "allowUnencryptedAssertion">>;

--- a/src/lib/interfaces/idp/organization/team/index.ts
+++ b/src/lib/interfaces/idp/organization/team/index.ts
@@ -12,11 +12,7 @@ export interface Team {
     creator: ReducedUser[];
 }
 
-export interface ReducedTeam {
-    _id: string;
-    name: string;
-    avatarUrl: string;
-}
+export type ReducedTeam = Pick<Team, "_id" | "name" | "avatarUrl">;
 
 export enum TeamUsersPatchOperation {
     ADD = "ADD",

--- a/src/lib/interfaces/idp/user/GeneralSettings.ts
+++ b/src/lib/interfaces/idp/user/GeneralSettings.ts
@@ -42,12 +42,4 @@ export interface GeneralSettings {
     entrypoint: Entrypoint;
 }
 
-export interface GeneralSettingsPatch {
-    lastUrl?: string;
-    lastView?: Views;
-    timezone?: string;
-    language?: Language;
-    entrypoint?: Entrypoint;
-    dateFormat?: DateFormat;
-    theme?: Theme;
-}
+export type GeneralSettingsPatch = Partial<Omit<GeneralSettings, "_id" | "userId">>;

--- a/src/lib/interfaces/idp/user/Pat.ts
+++ b/src/lib/interfaces/idp/user/Pat.ts
@@ -18,7 +18,4 @@ export interface PatCreate {
     scopes: Scope[];
 }
 
-export interface PatUpdate {
-    name: string;
-    scopes: Scope[];
-}
+export type PatUpdate = Omit<PatCreate, "expiration">;

--- a/src/lib/interfaces/idp/user/Totp.ts
+++ b/src/lib/interfaces/idp/user/Totp.ts
@@ -1,16 +1,18 @@
-export interface DeactivatedTotp {
+interface Totp {
     activated: boolean;
-    otpAuthUrl: string;
-    qrcode: string;
-    secret: string;
     createDate: number;
     modifyDate: number;
 }
-export interface ActivatedTotp {
-    activated: boolean;
+
+export interface DeactivatedTotp extends Totp {
+    activated: false;
+    otpAuthUrl: string;
+    qrcode: string;
+    secret: string;
+}
+export interface ActivatedTotp extends Totp {
+    activated: true;
     recoverCodes: string[];
-    createDate: number;
-    modifyDate: number;
 }
 
 export interface UserTotp {

--- a/src/lib/interfaces/idp/user/index.ts
+++ b/src/lib/interfaces/idp/user/index.ts
@@ -15,11 +15,7 @@ export interface User {
     activeScopes: Scope[];
 }
 
-export interface ReducedUser {
-    _id: string;
-    name: string;
-    avatarUrl: string;
-}
+export type ReducedUser = Pick<User, "_id" | "name" | "avatarUrl">;
 
 export interface PatchUser {
     name?: string;


### PR DESCRIPTION
- Extended base types when possible (e.g OrganizationWithPermission)
- Built create/patch/updateDTO types off of the "main" types to maintain consistency and remove duplicates
  - For example, if the "description" property gets removed from CronjobDto there will be an error in CronjobCreateDto now
  - If the "body" property of CronjobDto changes to an object instead of string the CronjobCreateDto will change as well
- Build the Reduced object off of the "main" counterparts using the Pick type