### PR TITLE
HCLOUD-1394_remove-settings-from-URL-when-working-with-secrets_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.50
+
+-   Adapt NATS interfaces to not have settings in their paths when working with secrets
+
 ## 0.0.49
 
 -   **BREAKING**: Move class High5Secret out of settings and delete settings folder and class

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.49",
+    "version": "0.0.50",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/nats/index.ts
+++ b/src/lib/interfaces/nats/index.ts
@@ -15,9 +15,9 @@ enum NatsSubject {
     HIGH5_STREAM_EXECUTE = "hcloud.high5.organization.${organizationId}.stream.execute.${base64email}",
     HIGH5_EVENTS = "hcloud.high5.organization.${organizationId}.space.${spaceId}.events",
     HIGH5_STREAMS = "hcloud.high5.organization.${organizationId}.space.${spaceId}.event.${eventId}.streams",
+    HIGH5_SECRETS = "hcloud.high5.organization.${organizationId}.space.${spaceId}.secrets",
     HIGH5_SETTINGS_GENERAL = "hcloud.high5.organization.${organizationId}.space.${spaceId}.settings.general",
     HIGH5_SETTINGS_WEBHOOKS = "hcloud.high5.organization.${organizationId}.space.${spaceId}.settings.webhooks",
-    HIGH5_SETTINGS_SECRETS = "hcloud.high5.organization.${organizationId}.space.${spaceId}.settings.secrets",
 
     FUSE_JOBS = "hcloud.fuse.jobs",
     FUSE_JOBS_TRIGGER = "hcloud.fuse.jobs.trigger",
@@ -140,15 +140,16 @@ class NatsSubjects {
                 };
             };
 
+            static SECRETS = (organizationId: string, spaceId: string) => {
+                return NatsSubjects.replace(NatsSubject.HIGH5_SECRETS, { organizationId, spaceId } as NatsSubjectReplacements);
+            };
+
             static Settings = class {
                 static GENERAL = (organizationId: string, spaceId: string) => {
                     return NatsSubjects.replace(NatsSubject.HIGH5_SETTINGS_GENERAL, { organizationId, spaceId } as NatsSubjectReplacements);
                 };
                 static WEBHOOKS = (organizationId: string, spaceId: string) => {
                     return NatsSubjects.replace(NatsSubject.HIGH5_SETTINGS_WEBHOOKS, { organizationId, spaceId } as NatsSubjectReplacements);
-                };
-                static SECRETS = (organizationId: string, spaceId: string) => {
-                    return NatsSubjects.replace(NatsSubject.HIGH5_SETTINGS_SECRETS, { organizationId, spaceId } as NatsSubjectReplacements);
                 };
             };
         };


### PR DESCRIPTION
Remove settings from paths in NATS interfaces when working with High5 secrets