### PR TITLE
HCLOUD-1625_Refactor-Organization-Interfaces_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.52
+
+-   **BREAKING**: Add field userRole to 'Organization' interface
+-   **BREAKING**: Replace 'OrganizationWithUserRole' and 'OrganizationWithUserRoleAndTeams' with conditional type 'OrganizationExtended'
+-   **BREAKING**: 'OrganizationExtended' will hold all fields of 'Organization' plus optional fields teamsOfUser, totalMembersCount and membersSample
+
 ## 0.0.51
 
 -   Add searchStreamsOfSpace method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/idp/organization/index.ts
+++ b/src/lib/interfaces/idp/organization/index.ts
@@ -15,17 +15,21 @@ export interface Organization {
     company: string;
     creator: ReducedUser;
     avatarUrl: string;
-    membersCount?: number;
+    roleOfUser: OrganizationRole;
     createDate: number;
     modifyDate: number;
 }
 
-export interface OrganizationWithUserRole extends Organization {
-    role: OrganizationRole;
+export interface OrganizationQueryOptions {
+    teamsOfUser?: boolean;
+    membersSample?: number; // number of members to return
 }
 
-export interface OrganizationWithUserRoleAndTeams extends OrganizationWithUserRole {
-    teams: ReducedTeam[];
-}
+export type ExtraFields<T extends OrganizationQueryOptions> = (T["teamsOfUser"] extends true
+    ? { teamsOfUser: ReducedTeam[] }
+    : Record<string, never>) &
+    (T["membersSample"] extends number ? { membersSample: ReducedUser[]; totalMembersCount: number } : Record<string, never>);
+
+export type OrganizationExtended<T extends OrganizationQueryOptions> = Organization & ExtraFields<T>;
 
 export type ReducedOrganization = Pick<Organization, "_id" | "name" | "avatarUrl">;

--- a/src/lib/service/idp/organization/index.ts
+++ b/src/lib/service/idp/organization/index.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../Base";
-import { Organization, OrganizationWithUserRole, OrganizationWithUserRoleAndTeams } from "../../../interfaces/idp/organization";
+import { Organization, OrganizationExtended, OrganizationQueryOptions } from "../../../interfaces/idp/organization";
 import { IdpOrganizationMember } from "./member";
 import { IdpOrganizationTeams } from "./team";
 import IdpOrganizationSettings from "./settings";
@@ -59,31 +59,19 @@ export class IdpOrganization extends Base {
     /**
      * Retrieves an Organization by its name.
      * @param orgName Name of the Organization
-     * @param options Object holding a teams property (boolean) which defines if the Teams of the Organization should be included in the response object.
+     * @param options Retrieve additional properties like teams (that the user is part of) or a sample of members.
      * @returns The requested Organization
      */
-    /* eslint-disable no-dupe-class-members */
-    public async getOrganization(orgName: string): Promise<OrganizationWithUserRole>;
-    public async getOrganization(orgName: string, options: { teams: false }): Promise<OrganizationWithUserRole>;
-    public async getOrganization(orgName: string, options: { teams: true }): Promise<OrganizationWithUserRoleAndTeams>;
-    public async getOrganization(
-        orgName: string,
-        options?: { teams: boolean }
-    ): Promise<OrganizationWithUserRole | OrganizationWithUserRoleAndTeams> {
-        let resp;
-        if (options?.teams) {
-            resp = await this.axios.get<OrganizationWithUserRoleAndTeams>(this.getEndpoint(`/v1/org/${orgName}`), {
-                params: {
-                    teams: options.teams,
-                },
-            });
-        } else {
-            resp = await this.axios.get<OrganizationWithUserRole>(this.getEndpoint(`/v1/org/${orgName}`));
-        }
+    public async getOrganization<T extends OrganizationQueryOptions>(orgName: string, options?: T): Promise<OrganizationExtended<T>> {
+        const resp = await this.axios.get<OrganizationExtended<T>>(this.getEndpoint(`/v1/org/${orgName}`), {
+            params: {
+                teams: options?.teamsOfUser,
+                membersLimit: options?.membersSample,
+            },
+        });
 
         return resp.data;
     }
-    /* eslint-enable no-dupe-class-members */
 
     /**
      * Deletes an Organization. This will also delete all dependencies that the Organization has (Teams, Spaces, apps, ...).


### PR DESCRIPTION
This is a draft. See linked Ticket for informations about what i did here.

    - Add userRole to 'Organization' interface
    - Replace 'OrganizationWithUserRole' and 'OrganizationWithUserRoleAndTeams' with conditional type 'OrganizationExtended'
    - 'OrganizationExtended' holds all fields of 'Organization' plus optional fields teamsOfUser, totalMembersCount and membersSample