### PR TITLE
HCLOUD-1601_Add-endpoint-in-idP-to-allow-users-to-manage-their-notification-settings_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.58
+
+-   Add endpoint to manage notification settings of user
+-   **BREAKING**: Fix interface GeneralSettings: Will return a ReducedUser instead of a userId
+
 ## 0.0.57
 
 -   Add mothership service to hcloud client
@@ -24,8 +29,9 @@
 ## 0.0.52
 
 -   **BREAKING**: Rework Organization interfaces: Combine all Organization interfaces into a single one with optional fields
--   **BREAKING**: Properties 'role' and 'teams' have been renamed to 'roleOfUser' and 'teamsOfUser' 
--   **BREAKING**: Update function getOrganization() to reflect these changes and also to reflect new query options to retrieve totalMemberCount and membersSample
+-   **BREAKING**: Properties 'role' and 'teams' have been renamed to 'roleOfUser' and 'teamsOfUser'
+-   **BREAKING**: Update function getOrganization() to reflect these changes and also to reflect new query options to retrieve totalMemberCount and
+    membersSample
 
 ## 0.0.51
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.57",
+    "version": "0.0.58",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/idp/user/GeneralSettings.ts
+++ b/src/lib/interfaces/idp/user/GeneralSettings.ts
@@ -1,3 +1,4 @@
+import { ReducedUser } from ".";
 import { Views } from "../../global/Views";
 
 export enum Language {
@@ -32,7 +33,7 @@ export enum Entrypoint {
 
 export interface GeneralSettings {
     _id: string;
-    userId: string;
+    user: ReducedUser;
     lastUrl: string;
     lastView: Views;
     timezone: string;
@@ -42,4 +43,4 @@ export interface GeneralSettings {
     entrypoint: Entrypoint;
 }
 
-export type GeneralSettingsPatch = Partial<Omit<GeneralSettings, "_id" | "userId">>;
+export type GeneralSettingsPatch = Partial<Omit<GeneralSettings, "_id" | "user">>;

--- a/src/lib/interfaces/idp/user/NotificationSettings.ts
+++ b/src/lib/interfaces/idp/user/NotificationSettings.ts
@@ -1,0 +1,10 @@
+import { ReducedUser } from ".";
+
+export interface NotificationSettings {
+    _id: string;
+    user: ReducedUser;
+    organizationInvitationEmail: boolean;
+    systemNotifications: boolean;
+}
+
+export type NotificationSettingsPatch = Partial<Omit<NotificationSettings, "_id" | "user">>;

--- a/src/lib/service/idp/registration/index.ts
+++ b/src/lib/service/idp/registration/index.ts
@@ -9,10 +9,9 @@ export class IdpRegistration extends Base {
     }
 
     /**
-     * Registers a User in the HCloud system. This endpoint will create all the necessary database entries that a User needs to use the HCloud products.
-     * It will also send a verification link (with expiration date) to the Users Email address. At this point the User will have an account status of
-     * 'AWAITING_VALIDATION' and cannot sign into his account. If the registration will not be validated before the expiration date, the User and all his
-     * dependencies will be deleted.
+     * Registers a User in the HCloud system. This endpoint will send a verification link (with expiration date) to the Users' email address.
+     * At this point the User will have an account status of 'AWAITING_VALIDATION' and cannot sign into his account. If the registration won't be
+     * validated before the expiration date, the user will be deleted again.
      * @param name - Name of the User
      * @param email - Email of the User
      * @param password - Password

--- a/src/lib/service/idp/user/settings/index.ts
+++ b/src/lib/service/idp/user/settings/index.ts
@@ -4,6 +4,7 @@ import { IdpPat } from "./pats";
 import { IdpTwoFactor } from "./twoFactor";
 import { IdpGeneral } from "./general";
 import { IdpOAuthApps } from "./oauthApps";
+import { IdpNotifications } from "./notifications";
 
 export class IdpSettings extends Base {
     /**
@@ -12,9 +13,14 @@ export class IdpSettings extends Base {
     public pat: IdpPat;
 
     /**
-     * Handles everything around a user's profile
+     * Handles everything around general user settings
      */
     public general: IdpGeneral;
+
+    /**
+     * Handles everything around notification settings of user
+     */
+    public notifications: IdpNotifications;
 
     /**
      * Manages user's OAuth applications
@@ -31,6 +37,7 @@ export class IdpSettings extends Base {
         this.pat = new IdpPat(options, axios);
         this.twoFactor = new IdpTwoFactor(options, axios);
         this.general = new IdpGeneral(options, axios);
+        this.notifications = new IdpNotifications(options, axios);
         this.oAuthApps = new IdpOAuthApps(options, axios);
     }
 

--- a/src/lib/service/idp/user/settings/notifications/index.ts
+++ b/src/lib/service/idp/user/settings/notifications/index.ts
@@ -1,0 +1,34 @@
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../../../Base";
+import { NotificationSettings, NotificationSettingsPatch } from "../../../../../interfaces/idp/user/NotificationSettings";
+
+export class IdpNotifications extends Base {
+    constructor(options: Options, axios: AxiosInstance) {
+        super(options, axios);
+    }
+
+    /**
+     * Retrieves the notification settings of the requesting user.
+     * @returns general settings of requesting user
+     */
+    public getNotificationSettingsOfUser = async (): Promise<NotificationSettings> => {
+        const resp = await this.axios.get<NotificationSettings>(this.getEndpoint(`/v1/user/settings/notifications`));
+
+        return resp.data;
+    };
+
+    /**
+     * Updates the notification settings of the requesting user.
+     * @param notificationSettingsPatch Object containing the new notification settings
+     * @returns the updated notification settings
+     */
+    public patchNotificationSettings = async (notificationSettingsPatch: NotificationSettingsPatch): Promise<NotificationSettings> => {
+        const resp = await this.axios.patch<NotificationSettings>(this.getEndpoint(`/v1/user/settings/notifications`), notificationSettingsPatch);
+
+        return resp.data;
+    };
+
+    protected getEndpoint(endpoint: string): string {
+        return `${this.options.server}/api/account${endpoint}`;
+    }
+}


### PR DESCRIPTION
Add endpoint to manage user notification settings and fix GeneralSettings interface