### PR TITLE
HCLOUD-1746_Add-MemberSample-to-returned-orgs-of-searchOrganizationsOfUser-endpoint_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.71
+
+-   Add option to retrieve additional properties (membersSample, totalMemberCount, ...) when searching users organizations
+
 ## 0.0.70
 
 -   Add service to manage design snapshots

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.70",
+    "version": "0.0.71",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",


### PR DESCRIPTION
Add option to retrieve additional properties (membersSample, totalMemberCount, teamsOfUser) when searching organizations of user

Linked IDP PR: https://github.com/moovit-sp-gmbh/hcloud-idp-backend/pull/326