### PR TITLE
HCLOUD-1452_Further-SDK-improvements_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.78
+
+-   **BREAKING**: Rename multiple interfaces to be consistent to our naming conventions (for example, CronjobCreate instead of CreateCronjob)
+-   **BREAKING**: Remove properties 'name' and 'description' from SearchFilter interface
+-   Fix wrong return type of getStreamExecutionLog() function
+
 ## 0.0.77
 
 -   **BREAKING**: Rename totalMembersCount to totalMemberCount in Team interface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.77",
+    "version": "0.0.78",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/Hcloud.ts
+++ b/src/lib/Hcloud.ts
@@ -56,42 +56,70 @@ export default class HCloud {
         this.Nats = new NatsService();
     }
 
+    /**
+     * Sets the server url that the SDK shall do a request to.
+     */
     setServer(server: string): HCloud {
         this.options.server = server;
         return this;
     }
 
+    /**
+     * Returns the currently set server url that the SDK will make requests to.
+     */
     getServer(): string {
         return this.options.server;
     }
 
+    /**
+     * Authenticate against hcloud with username and password, as an alternative to using a bearer auth token.
+     */
     setBasicAuth(username: string, password: string): HCloud {
         this.axios.defaults.headers.common["authorization"] = `Basic ${Buffer.from(username + ":" + password).toString("base64")}`;
         return this;
     }
 
+    /**
+     * Sets the auth token used for authentication against hcloud. The provided token must be a bearer token.
+     */
     setAuthToken(token: string): HCloud {
         this.axios.defaults.headers.common["authorization"] = token;
         return this;
     }
 
+    /**
+     * Returns the currently set auth token.
+     */
     getAuthToken(): string | undefined {
         return this.axios.defaults.headers.common["authorization"]?.toString();
     }
 
+    /**
+     * Sets the correlationID which will be sent to hcloud with each request and appears in all
+     * logs that are made on behalf of this request, making it easier to debug the application.
+     */
     setCorrelationId(correlationId: string): HCloud {
         this.axios.defaults.headers.common["X-Hcloud-Correlation-ID"] = correlationId;
         return this;
     }
 
+    /**
+     * Returns the currently set correlationID.
+     */
     getCorrelationId(): string | undefined {
         return this.axios.defaults.headers.common["X-Hcloud-Correlation-ID"]?.toString();
     }
 
+    /**
+     * Returns the currently set logger.
+     */
     getLogger(): HcloudLogger | undefined {
         return this.options.logger;
     }
 
+    /**
+     * Sets a logger used to receive logs from hcloud.
+     */
     setLogger(logger: HcloudLogger) {
         this.options.logger = logger;
         return this;

--- a/src/lib/helper/ErrorHelper.ts
+++ b/src/lib/helper/ErrorHelper.ts
@@ -14,6 +14,10 @@ export default function wrapError<T>(error: T): T | HCloudError {
     return error;
 }
 
+/**
+ * Checks if error is of type HCloudError. An HCloudError is comming from the SDK and holds
+ * the information of a custom error that was initially thrown in a hcloud backend.
+ */
 export function isHCloudError(obj: unknown): obj is HCloudError {
     return typeof obj === "object" && obj instanceof HCloudError;
 }

--- a/src/lib/interfaces/fuse/space/cronjob/Cronjob.ts
+++ b/src/lib/interfaces/fuse/space/cronjob/Cronjob.ts
@@ -22,5 +22,5 @@ export interface Cronjob {
     nextExecution?: number;
 }
 
-export type CreateCronjob = Pick<Cronjob, "name" | "expression" | "targetUrl" | "httpMethod" | "headers" | "body" | "enabled" | "description"> &
+export type CronjobCreate = Pick<Cronjob, "name" | "expression" | "targetUrl" | "httpMethod" | "headers" | "body" | "enabled" | "description"> &
     Partial<Pick<Cronjob, "acceptInvalidSSL" | "timezone">>;

--- a/src/lib/interfaces/fuse/space/cronjob/CronjobLog.ts
+++ b/src/lib/interfaces/fuse/space/cronjob/CronjobLog.ts
@@ -15,4 +15,4 @@ export interface CronjobLogDto {
     modifyDate: number;
 }
 
-export type CronjobLogCreation = Pick<CronjobLogDto, "statusCode" | "headers" | "body">;
+export type CronjobLogCreate = Pick<CronjobLogDto, "statusCode" | "headers" | "body">;

--- a/src/lib/interfaces/global/SearchFilters.ts
+++ b/src/lib/interfaces/global/SearchFilters.ts
@@ -44,9 +44,7 @@ export enum SearchFilterType {
 export interface SearchFilter {
     type: SearchFilterType;
     key: string;
-    name: string;
     comparator?: SearchFilterComparatorBoolean | SearchFilterComparatorDate | SearchFilterComparatorNumber | SearchFilterComparatorString;
-    description: string;
 }
 
 export interface SearchFilterString extends SearchFilter {

--- a/src/lib/interfaces/high5/space/webhook/index.ts
+++ b/src/lib/interfaces/high5/space/webhook/index.ts
@@ -50,9 +50,9 @@ export interface Webhook {
     modifyDate: number;
 }
 
-export type WebhookCreation = Pick<Webhook, "name" | "target" | "type" | "sub" | "webhookEncryptionSettings" | "securityHeaders">;
+export type WebhookCreate = Pick<Webhook, "name" | "target" | "type" | "sub" | "webhookEncryptionSettings" | "securityHeaders">;
 
-export type WebhookUpdate = Partial<WebhookCreation> & {
+export type WebhookUpdate = Partial<WebhookCreate> & {
     deleteWebhookEncryptionSettings?: boolean;
     deleteSecurityHeaders?: boolean;
 };

--- a/src/lib/interfaces/idp/organization/member/index.ts
+++ b/src/lib/interfaces/idp/organization/member/index.ts
@@ -8,11 +8,11 @@ export interface OrganizationMember {
     role: OrganizationRole;
 }
 
-export interface AddOrganizationMember {
+export interface OrgMemberCreate {
     email: string;
     role: OrganizationRole;
 }
 
-export interface PatchOrgMember {
+export interface OrgMemberPatch {
     role: OrganizationRole;
 }

--- a/src/lib/interfaces/idp/organization/settings/oauthApp/index.ts
+++ b/src/lib/interfaces/idp/organization/settings/oauthApp/index.ts
@@ -29,7 +29,7 @@ export interface OAuthApp {
     modifyDate: number;
 }
 
-export interface OAuthAppCreation {
+export interface OAuthAppCreate {
     name: string;
     description?: string;
     homepage?: string;

--- a/src/lib/interfaces/idp/user/index.ts
+++ b/src/lib/interfaces/idp/user/index.ts
@@ -17,7 +17,7 @@ export interface User {
 
 export type ReducedUser = Pick<User, "_id" | "name" | "avatarUrl">;
 
-export interface PatchUser {
+export interface UserPatch {
     name?: string;
     email?: string;
     company?: string;

--- a/src/lib/service/fuse/internal/space/cronjob/log/index.ts
+++ b/src/lib/service/fuse/internal/space/cronjob/log/index.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../../../Base";
-import { CronjobLogCreation, CronjobLogDto } from "../../../../../../interfaces/fuse/space/cronjob/CronjobLog";
+import { CronjobLogCreate, CronjobLogDto } from "../../../../../../interfaces/fuse/space/cronjob/CronjobLog";
 
 export class FuseCronjobLogInternal extends Base {
     constructor(options: Options, axios: AxiosInstance) {
@@ -16,7 +16,7 @@ export class FuseCronjobLogInternal extends Base {
      * @param createCronjob Cronjob log to be created
      * @returns the created cronjob log with metadata
      */
-    public createCronjobLog = async (orgName: string, spaceName: string, cronjobId: string, log: CronjobLogCreation): Promise<CronjobLogDto> => {
+    public createCronjobLog = async (orgName: string, spaceName: string, cronjobId: string, log: CronjobLogCreate): Promise<CronjobLogDto> => {
         const resp = await this.axios.post<CronjobLogDto>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/jobs/${cronjobId}/logs}`), log);
 
         return resp.data;

--- a/src/lib/service/fuse/space/cronjob/index.ts
+++ b/src/lib/service/fuse/space/cronjob/index.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../Base";
 import { SearchFilterDTO } from "../../../../helper/searchFilter";
-import { CreateCronjob, Cronjob } from "../../../../interfaces/fuse/space/cronjob/Cronjob";
+import { CronjobCreate, Cronjob } from "../../../../interfaces/fuse/space/cronjob/Cronjob";
 import { SearchFilter, SearchParams } from "../../../../interfaces/global";
 import { FuseCronjobLog } from "./log";
 import { FuseCronjobLogInternal } from "../../internal/space/cronjob/log";
@@ -56,7 +56,7 @@ export class FuseCronjob extends Base {
     public createCronjob = async (
         orgName: string,
         spaceName: string,
-        createCronjob: CreateCronjob,
+        createCronjob: CronjobCreate,
         exposeNextExecution = false
     ): Promise<Cronjob> => {
         const resp = await this.axios.post<Cronjob>(
@@ -79,7 +79,7 @@ export class FuseCronjob extends Base {
         orgName: string,
         spaceName: string,
         cronjobId: string,
-        createCronjob: CreateCronjob,
+        createCronjob: CronjobCreate,
         exposeNextExecution = false
     ): Promise<Cronjob> => {
         const resp = await this.axios.put<Cronjob>(

--- a/src/lib/service/high5/space/execution/log/index.ts
+++ b/src/lib/service/high5/space/execution/log/index.ts
@@ -41,20 +41,20 @@ export class High5ExecutionLogs extends Base {
     };
 
     /**
-     * Retrieves all stream execution logs for a given stream.
+     * Retrieves the execution log of a stream.
      * @param orgName Name of the Organization
      * @param spaceName Name of the Space
      * @param streamLogId ID of the stream log
-     * @returns Array of Stream execution logs as well as the total number of results
+     * @returns Stream execution log
      */
-    public getStreamExecutionLog = async (orgName: string, spaceName: string, streamLogId: string): Promise<[High5ExecutionLog, number]> => {
+    public getStreamExecutionLog = async (orgName: string, spaceName: string, streamLogId: string): Promise<High5ExecutionLog> => {
         const resp = await this.axios
             .get<High5ExecutionLog>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execution/streams/logs/${streamLogId}`))
             .catch((err: Error) => {
                 throw err;
             });
 
-        return [resp.data, parseInt(String(resp.headers["total"]), 10)];
+        return resp.data;
     };
 
     protected getEndpoint(endpoint: string): string {

--- a/src/lib/service/high5/space/webhook/index.ts
+++ b/src/lib/service/high5/space/webhook/index.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../Base";
-import { KeyValuePair, Webhook, WebhookCreation, WebhookUpdate } from "../../../../interfaces/high5/space/webhook";
+import { KeyValuePair, Webhook, WebhookCreate, WebhookUpdate } from "../../../../interfaces/high5/space/webhook";
 import { High5WebhookLog } from "./log";
 import { SearchFilter, SearchParams } from "../../../../interfaces/global";
 import { SearchFilterDTO } from "../../../../helper/searchFilter";
@@ -74,11 +74,11 @@ export class High5Webhook extends Base {
      * Creates a new Webhook in the specified High5 space.
      * @param orgName Name of the Organization
      * @param spaceName Name of the Space
-     * @param webhookCreation Object/JSON containing the name, token, eventId, spaceId, target and (optionally) security headers for the new webhook
+     * @param WebhookCreate Object/JSON containing the name, token, eventId, spaceId, target and (optionally) security headers for the new webhook
      * @returns The created Webhook
      */
-    public createWebhook = async (orgName: string, spaceName: string, webhookCreation: WebhookCreation): Promise<Webhook> => {
-        const resp = await this.axios.post<Webhook>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/webhooks`), webhookCreation);
+    public createWebhook = async (orgName: string, spaceName: string, WebhookCreate: WebhookCreate): Promise<Webhook> => {
+        const resp = await this.axios.post<Webhook>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/webhooks`), WebhookCreate);
 
         return resp.data;
     };
@@ -88,7 +88,7 @@ export class High5Webhook extends Base {
      * @param orgName Name of the Organization
      * @param spaceName Name of the Space
      * @param webhookId ID of the Webhook to be updated
-     * @param webhookCreation Object/JSON containing the name, token, eventId, spaceId, target and (optionally) security headers for the updated webhook
+     * @param WebhookCreate Object/JSON containing the name, token, eventId, spaceId, target and (optionally) security headers for the updated webhook
      * @returns the updated Webhook
      */
     public updateWebhook = async (orgName: string, spaceName: string, webhookId: string, webhookUpdate: WebhookUpdate): Promise<Webhook> => {

--- a/src/lib/service/idp/organization/member/index.ts
+++ b/src/lib/service/idp/organization/member/index.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../Base";
 import { SearchFilterDTO } from "../../../../helper/searchFilter";
 import { SearchFilter, SearchParams } from "../../../../interfaces/global";
-import { OrganizationMember, PatchOrgMember } from "../../../../interfaces/idp/organization/member";
+import { OrganizationMember, OrgMemberPatch } from "../../../../interfaces/idp/organization/member";
 import IdpOrganizationMemberInvitations from "./invitations";
 
 export class IdpOrganizationMember extends Base {
@@ -54,11 +54,11 @@ export class IdpOrganizationMember extends Base {
      * Updates the role of a User in the specified Organization.
      * @param orgName Name of the Organization
      * @param userId ID of the User
-     * @param patchOrgMember New role
+     * @param orgMemberPatch New role
      * @returns The updated OrganizationMember
      */
-    public patchOrganizationMemberRole = async (orgName: string, userId: string, patchOrgMember: PatchOrgMember): Promise<OrganizationMember> => {
-        const resp = await this.axios.patch<OrganizationMember>(this.getEndpoint(`/${orgName}/members/${userId}/role`), patchOrgMember);
+    public patchOrganizationMemberRole = async (orgName: string, userId: string, orgMemberPatch: OrgMemberPatch): Promise<OrganizationMember> => {
+        const resp = await this.axios.patch<OrganizationMember>(this.getEndpoint(`/${orgName}/members/${userId}/role`), orgMemberPatch);
 
         return resp.data;
     };

--- a/src/lib/service/idp/organization/settings/oauth/index.ts
+++ b/src/lib/service/idp/organization/settings/oauth/index.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../../Base";
 import { SearchFilterDTO } from "../../../../../helper/searchFilter";
 import { SearchFilter, SearchParams } from "../../../../../interfaces/global";
-import { OAuthApp, OAuthAppCreation } from "../../../../../interfaces/idp/organization/settings/oauthApp";
+import { OAuthApp, OAuthAppCreate } from "../../../../../interfaces/idp/organization/settings/oauthApp";
 
 export class IdpOAuthApp extends Base {
     constructor(options: Options, axios: AxiosInstance) {
@@ -55,11 +55,11 @@ export class IdpOAuthApp extends Base {
     /**
      * Creates a new OAuth app in the specified Organization.
      * @param orgName Name of the Organization
-     * @param oAuthAppCreation Object containing the app's name, secretName, callback and optionally a base64 encoded avatar and a description
+     * @param oAuthAppCreate Object containing the app's name, secretName, callback and optionally a base64 encoded avatar and a description
      * @returns The created OAuth app
      */
-    public createOAuthApp = async (orgName: string, oAuthAppCreation: OAuthAppCreation): Promise<OAuthApp> => {
-        const resp = await this.axios.post<OAuthApp>(this.getEndpoint(`/v1/org/${orgName}/settings/applications/oauth`), oAuthAppCreation);
+    public createOAuthApp = async (orgName: string, oAuthAppCreate: OAuthAppCreate): Promise<OAuthApp> => {
+        const resp = await this.axios.post<OAuthApp>(this.getEndpoint(`/v1/org/${orgName}/settings/applications/oauth`), oAuthAppCreate);
 
         return resp.data;
     };
@@ -68,14 +68,11 @@ export class IdpOAuthApp extends Base {
      * Updates an existing OAuth app.
      * @param orgName Name of the Organization
      * @param oauthAppId ID of the OAuth app to be updated
-     * @param oAuthAppCreation Object containing the app's name, secretName, callback and optionally a base64 encoded avatar and a description
+     * @param oAuthAppCreate Object containing the app's name, secretName, callback and optionally a base64 encoded avatar and a description
      * @returns the updated OAuth app
      */
-    public updateOAuthApp = async (orgName: string, oauthAppId: string, oAuthAppCreation: OAuthAppCreation): Promise<OAuthApp> => {
-        const resp = await this.axios.put<OAuthApp>(
-            this.getEndpoint(`/v1/org/${orgName}/settings/applications/oauth/${oauthAppId}`),
-            oAuthAppCreation
-        );
+    public updateOAuthApp = async (orgName: string, oauthAppId: string, oAuthAppCreate: OAuthAppCreate): Promise<OAuthApp> => {
+        const resp = await this.axios.put<OAuthApp>(this.getEndpoint(`/v1/org/${orgName}/settings/applications/oauth/${oauthAppId}`), oAuthAppCreate);
 
         return resp.data;
     };

--- a/src/lib/service/idp/user/index.ts
+++ b/src/lib/service/idp/user/index.ts
@@ -3,7 +3,7 @@ import Base, { Options } from "../../../Base";
 import { SearchFilterDTO } from "../../../helper/searchFilter";
 import { SearchFilter, Sorting } from "../../../interfaces/global/SearchFilters";
 import { Organization, OrganizationQueryOptions } from "../../../interfaces/idp/organization";
-import { PatchUser, User } from "../../../interfaces/idp/user";
+import { UserPatch, User } from "../../../interfaces/idp/user";
 import { IdpSettings } from "./settings";
 
 export class IdpUser extends Base {
@@ -30,10 +30,10 @@ export class IdpUser extends Base {
 
     /**
      * Updates the User database entry of the requesting user.
-     * @param user PatchUser object holding the new User values
+     * @param user UserPatch object holding the new User values
      * @returns User object
      */
-    public patchUser = async (user: PatchUser): Promise<User> => {
+    public patchUser = async (user: UserPatch): Promise<User> => {
         const resp = await this.axios.patch<User>(this.getEndpoint(`/v1/user`), user);
 
         return resp.data;


### PR DESCRIPTION
Some SDK cleanup:
- Rename multiple interfaces to be consistent to our naming conventions
- Remove properties 'name' and 'description' from SearchFilter interface
- Fix wrong return type of getStreamExecutionLog() function

### This is for review because of a question:
Was there a reason for adding the properties 'name' and 'description' to the SearchFilter? These properties are not used in the SDK nor in any backend, which is why i removed them. 

