### PR TITLE
HCLOUD-1746_Add-MemberSample-to-returned-orgs-of-searchOrganizationsOfUser-endpoint-and-searchTeams_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.76
+
+-   Add option to retrieve additional properties when requesting teams via searchTeams
+-   **BREAKING**: Remove listTeams function (use searchTeams instead)
+
 ## 0.0.75
 
 -   Add ability to start an empty Design operation queue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.75",
+    "version": "0.0.76",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/idp/organization/team/index.ts
+++ b/src/lib/interfaces/idp/organization/team/index.ts
@@ -10,6 +10,8 @@ export interface Team {
     createDate: number;
     modifyDate: number;
     creator: ReducedUser;
+    membersSample?: ReducedUser[];
+    totalMembersCount?: number;
 }
 
 export type ReducedTeam = Pick<Team, "_id" | "name" | "avatarUrl">;
@@ -19,3 +21,8 @@ export enum TeamUsersPatchOperation {
     REMOVE = "REMOVE",
     SET = "SET",
 }
+
+export type TeamQueryOptions = {
+    getMembersSample?: number; // Number of members to return
+    getTotalMemberCount?: boolean;
+};


### PR DESCRIPTION
Add option to retrieve additional properties for teams when using searchTeams() and remove listTeams as it got replaced by searchTeams