### PR TITLE
HCLOUD-1855_Add-search-filter-to-the-endpoint-accountv1orgORGNAMEmembers-to-return-the-members-that-are-not-in-a-specified-team_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.82
+
+-   **BREAKING**: Update searchOrganizationMembers function accept a team name instead of team id and make this argument optional
+
 ## 0.0.81
 
 -   **BREAKING**: Update searchOrganizationMembers function to allow excluding members of a specific team

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.81",
+    "version": "0.0.82",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/service/idp/organization/member/index.ts
+++ b/src/lib/service/idp/organization/member/index.ts
@@ -17,7 +17,7 @@ export class IdpOrganizationMember extends Base {
      * Retrieves all organization members that match the provided search filter(s). Will return all members of the organization if no search filter is provided.
      * @param orgName Name of the Organization
      * @param filters (optional) Array of search filters
-     * @param excludeTeamById (optional) ID of a team whos members shall be excluded
+     * @param excludeTeamByName (optional) Name of a team whos members shall be excluded
      * @param sorting (optional) Sorting object
      * @param limit (optional) Max number of results (1-100; defaults to 25)
      * @param page (optional) Page number to skip the first (page * limit) results (defaults to 0)
@@ -26,11 +26,11 @@ export class IdpOrganizationMember extends Base {
     public searchOrganizationMembers = async ({
         orgName,
         filters,
-        excludeTeamById,
+        excludeTeamByName,
         sorting,
         limit = 25,
         page = 0,
-    }: SearchParams & { orgName: string; excludeTeamById: string }): Promise<[OrganizationMember[], number]> => {
+    }: SearchParams & { orgName: string; excludeTeamByName?: string }): Promise<[OrganizationMember[], number]> => {
         const filtersDTO = filters?.map((f: SearchFilter) => {
             return new SearchFilterDTO(f);
         });
@@ -39,7 +39,7 @@ export class IdpOrganizationMember extends Base {
                 filters: filtersDTO,
                 sorting: sorting,
             },
-            excludeTeamById: excludeTeamById,
+            excludeTeamByName,
         });
 
         return [resp.data, parseInt(String(resp.headers["total"]), 10)];


### PR DESCRIPTION
Make searchOrganizationMembers function accept a team name instead of team id and make this argument optional