### PR TITLE
HCLOUD-1876_allows-to-PATCH-a-PATs-expiration-date_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/idp/user/Pat.ts
+++ b/src/lib/interfaces/idp/user/Pat.ts
@@ -18,4 +18,4 @@ export interface PatCreate {
     scopes: Scope[];
 }
 
-export type PatUpdate = Omit<PatCreate, "expiration">;
+export type PatUpdate = Partial<PatCreate>;

--- a/src/lib/service/idp/user/settings/pats/index.ts
+++ b/src/lib/service/idp/user/settings/pats/index.ts
@@ -52,8 +52,11 @@ export class IdpPat extends Base {
 
     /**
      * Updates an existing PAT object.
+     *
+     * Use an expiration value of -1 to remove the token's expiration date.
+     *
      * @param patId ID of the pat object
-     * @param patUpdate Object containing new name and scopes
+     * @param patUpdate Object containing new name, expiration and scopes
      * @returns the updated PAT object
      */
     public updatePat = async (patId: string, patUpdate: PatUpdate): Promise<Pat> => {


### PR DESCRIPTION
Update PAT update endpoint to allow expiration

    - A value of -1 can be used for the token to not expire.