### PR TITLE
HCLOUD-1907_Update-the-uptime-field-to-the-agents-uptime-instead-of-the-machine-uptime_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/mothership/index.ts
+++ b/src/lib/interfaces/mothership/index.ts
@@ -22,6 +22,8 @@ export type Agent = {
     modifyDate: number;
 };
 
-export type TargetAgent = Agent & {
-    targetEmail: string;
-};
+export type TargetAgent =
+    | Pick<Agent, Exclude<keyof Agent, "uptime">> & {
+          connectionUptime: number;
+          targetEmail: string;
+      };


### PR DESCRIPTION
Update TargetAgent to have connectionUptime

    - This replaces uptime and represents the connection uptime
       to the organization used the path of the searchTargets endpoint.