### PR TITLE
HCLOUD-1847_Re-establish-md5-check-for-wave-engine-right-before-execution_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -18,6 +18,7 @@ export interface WaveEngine {
     version: string;
     url: string;
     changeLog: string[];
+    md5: string;
 }
 
 export interface WaveCatalog {


### PR DESCRIPTION
Add md5 file hash prop to WaveEngine interface