### PR TITLE
HCLOUD-1963_Changes-to-the-PAT-should-require-a-TOTP-code-if-2FA-is-enabled_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/idp/user/Pat.ts
+++ b/src/lib/interfaces/idp/user/Pat.ts
@@ -16,6 +16,8 @@ export interface PatCreate {
     name: string;
     expiration?: number;
     scopes: Scope[];
+    // 2FA TOTP token
+    token?: string;
 }
 
 export type PatUpdate = Partial<PatCreate>;

--- a/src/lib/service/idp/user/settings/pats/index.ts
+++ b/src/lib/service/idp/user/settings/pats/index.ts
@@ -33,8 +33,8 @@ export class IdpPat extends Base {
      * @param patId ID of the PAT
      * @returns PAT object holding the updated token
      */
-    public regeneratePat = async (patId: string): Promise<Pat> => {
-        const resp = await this.axios.patch<Pat>(this.getEndpoint(`/v1/user/settings/pats/${patId}/regenerate`));
+    public regeneratePat = async (patId: string, token?: string): Promise<Pat> => {
+        const resp = await this.axios.patch<Pat>(this.getEndpoint(`/v1/user/settings/pats/${patId}/regenerate`), { token });
 
         return resp.data;
     };


### PR DESCRIPTION
Update PAT endpoints to take optional TOTP token