### PR TITLE
HCLOUD-1958_Remove-execute-role-from-Fuse_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.93
+
+-   **BREAKING**: Remove centralized SpacePermission and SpaceEntityPermission interface and create separate ones for Fuse and High5
+
 ## 0.0.92
 
 -   Add optional targetUrl parameter to Register/Renew register and forgot password endpoints. That one will be used for link creation in the corresponding mail

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.92",
+    "version": "0.0.93",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/fuse/space/index.ts
+++ b/src/lib/interfaces/fuse/space/index.ts
@@ -1,4 +1,20 @@
-import { Space } from "../../global";
+import { Space, SpaceEntity } from "../../global";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FuseSpace extends Space {}
+type ExtendWith<T1, T2> = T1 & T2;
+
+export interface FuseSpace extends Space {
+    permissions: ExtendWith<FuseSpaceEntityPermission, { name: string }>[];
+}
+export interface FuseSpaceEntityPermission {
+    entityId: string;
+    type: SpaceEntity;
+    permission: FuseSpacePermission;
+}
+
+export enum FuseSpacePermission {
+    NONE = "NONE",
+    READ = "READ",
+    WRITE = "WRITE",
+    MANAGE = "MANAGE",
+    OWNER = "OWNER",
+}

--- a/src/lib/interfaces/global/Space.ts
+++ b/src/lib/interfaces/global/Space.ts
@@ -1,33 +1,12 @@
 import { ReducedOrganization } from "../idp/organization";
 import { ReducedUser } from "../idp/user";
 
-type ExtendWith<T1, T2> = T1 & T2;
-
-export enum SpacePermission {
-    NONE = "NONE",
-    READ = "READ",
-    EXECUTE = "EXECUTE",
-    WRITE = "WRITE",
-    MANAGE = "MANAGE",
-    OWNER = "OWNER",
-}
-export enum SpaceEntity {
-    TEAM = "team",
-    USER = "user",
-}
-export interface SpaceEntityPermission {
-    entityId: string;
-    type: SpaceEntity;
-    permission: SpacePermission;
-}
-
 export interface Space {
     _id: string;
     name: string;
     organization: ReducedOrganization;
     avatarUrl: string;
     creator: ReducedUser;
-    permissions: ExtendWith<SpaceEntityPermission, { name: string }>[];
     createDate: number;
     modifyDate: number;
 }
@@ -36,4 +15,9 @@ export interface ReducedSpace {
     _id: string;
     name: string;
     avatarUrl: string;
+}
+
+export enum SpaceEntity {
+    TEAM = "team",
+    USER = "user",
 }

--- a/src/lib/interfaces/high5/space/index.ts
+++ b/src/lib/interfaces/high5/space/index.ts
@@ -1,5 +1,22 @@
-import { Space } from "../../global";
+import { Space, SpaceEntity } from "../../global";
+
+type ExtendWith<T1, T2> = T1 & T2;
 
 export interface High5Space extends Space {
+    permissions: ExtendWith<High5SpaceEntityPermission, { name: string }>[];
     waveEngine: string;
+}
+export interface High5SpaceEntityPermission {
+    entityId: string;
+    type: SpaceEntity;
+    permission: High5SpacePermission;
+}
+
+export enum High5SpacePermission {
+    NONE = "NONE",
+    READ = "READ",
+    EXECUTE = "EXECUTE",
+    WRITE = "WRITE",
+    MANAGE = "MANAGE",
+    OWNER = "OWNER",
 }

--- a/src/lib/service/fuse/space/index.ts
+++ b/src/lib/service/fuse/space/index.ts
@@ -1,10 +1,10 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../Base";
-import { PaginatedResponse, SearchFilter, SearchParams, SpacePermission } from "../../../interfaces/global";
+import { PaginatedResponse, SearchFilter, SearchParams } from "../../../interfaces/global";
 import { SearchFilterDTO } from "../../../helper/searchFilter";
 import { createPaginatedResponse } from "../../../helper/paginatedResponseHelper";
 import { FuseCronjob } from "./cronjob";
-import { FuseSpace as IFuseSpace } from "../../../interfaces/fuse/space";
+import { FuseSpace as IFuseSpace, FuseSpacePermission as SpacePermission } from "../../../interfaces/fuse/space";
 
 export class FuseSpace extends Base {
     public cronjob: FuseCronjob;

--- a/src/lib/service/high5/space/index.ts
+++ b/src/lib/service/high5/space/index.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../Base";
-import { High5Space as Space } from "../../../interfaces/high5/space";
-import { PaginatedResponse, SearchFilter, SearchParams, SpacePermission } from "../../../interfaces/global";
+import { High5Space as Space, High5SpacePermission as SpacePermission } from "../../../interfaces/high5/space";
+import { PaginatedResponse, SearchFilter, SearchParams } from "../../../interfaces/global";
 import { SearchFilterDTO } from "../../../helper/searchFilter";
 import { createPaginatedResponse } from "../../../helper/paginatedResponseHelper";
 import { High5Event } from "./event";


### PR DESCRIPTION
Remove centralized SpacePermission and SpaceEntityPermission interfaces and create separate ones for Fuse and High5. Needed because Fuse and High5 now have different SpacePermissions.

Linked PRs:
backend-core: https://github.com/moovit-sp-gmbh/backend-core/pull/67
Fuse: https://github.com/moovit-sp-gmbh/hcloud-fuse-backend/pull/103
High5: https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/233