### PR TITLE
HCLOUD-1965_change-target-URL-when-sending-a-verify-link-via-mail-v2_Artur-Grafov

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.92
+
+-   Add optional targetUrl parameter to Register/Renew register and forgot password endpoints. That one will be used for link creation in the corresponding mail
+
 ## 0.0.91
 
 -   **BREAKING**: Rename customTag to tag in interface StreamNodeSecification

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.91",
+    "version": "0.0.92",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/service/idp/index.ts
+++ b/src/lib/service/idp/index.ts
@@ -152,9 +152,10 @@ export default class Idp extends Base {
      * @param email Email of the user
      * @param captcha Valid google reCAPTCHAV2
      * @param regionId Optional region id to use for the password reset email
+     * @param targetUrl Optional url the link in the mail will point to
      */
-    resetPassword = async (email: string, captcha: string, regionId?: string): Promise<void> => {
-        await this.axios.post<void>(this.getEndpoint("/v1/login/forgot_password"), { email, captcha, regionId });
+    resetPassword = async (email: string, captcha: string, regionId?: string, targetUrl?: string): Promise<void> => {
+        await this.axios.post<void>(this.getEndpoint("/v1/login/forgot_password"), { email, captcha, regionId, targetUrl });
     };
 
     protected getEndpoint(endpoint: string): string {

--- a/src/lib/service/idp/organization/member/invitations/index.ts
+++ b/src/lib/service/idp/organization/member/invitations/index.ts
@@ -50,18 +50,21 @@ export default class IdpOrganizationMemberInvitations extends Base {
      * @param allowNonRegisteredUsers Flag to determine if the invitation should go through in the case that the email is not bound to an Helmut Cloud user.
      *                                If this is set to true and the email is unbound, then an email will be sent asking the person to register.
      *                                When they do they will automatically join the organization.
+     * @param targetUrl Optional url the link in the mail will point to
      * @returns The created invitation
      */
     public create = async (
         orgName: string,
         email: string,
         role: OrganizationRole,
-        allowNonRegisteredUsers = false
+        allowNonRegisteredUsers = false,
+        targetUrl?: string
     ): Promise<OrganizationMemberInvitation> => {
         const resp = await this.axios.post<OrganizationMemberInvitation>(this.getEndpoint(`/${orgName}/members/invitations`), {
             email,
             role,
             allowNonRegisteredUsers,
+            targetUrl,
         });
 
         return resp.data;

--- a/src/lib/service/idp/registration/index.ts
+++ b/src/lib/service/idp/registration/index.ts
@@ -18,8 +18,17 @@ export class IdpRegistration extends Base {
      * @param captcha - Captcha
      * @param company - Optional company name
      * @param regionId - Optional region id
+     * @param targetUrl Optional url the link in the mail will point to
      */
-    register = async (name: string, email: string, password: string, captcha: string, company?: string, regionId?: string): Promise<void> => {
+    register = async (
+        name: string,
+        email: string,
+        password: string,
+        captcha: string,
+        company?: string,
+        regionId?: string,
+        targetUrl?: string
+    ): Promise<void> => {
         await this.axios.post<void>(this.getEndpoint("/v1/register"), {
             name: name,
             email: email,
@@ -27,6 +36,7 @@ export class IdpRegistration extends Base {
             captcha: captcha,
             company,
             regionId,
+            targetUrl,
         });
     };
 
@@ -38,6 +48,7 @@ export class IdpRegistration extends Base {
      * @param captcha - Captcha
      * @param company - Optional company name
      * @param regionId - Optional region id
+     * @param targetUrl Optional url the link in the mail will point to
      */
     resendRegistrationMail = async (
         name: string,
@@ -45,7 +56,8 @@ export class IdpRegistration extends Base {
         password: string,
         captcha: string,
         company?: string,
-        regionId?: string
+        regionId?: string,
+        targetUrl?: string
     ): Promise<void> => {
         await this.axios.patch<void>(this.getEndpoint("/v1/register/resendRegistrationEmail"), {
             name: name,
@@ -54,6 +66,7 @@ export class IdpRegistration extends Base {
             captcha: captcha,
             company,
             regionId,
+            targetUrl,
         });
     };
 


### PR DESCRIPTION
Add optional targetUrl parameter to register/renew register and forgot password endpoints