### PR TITLE
HCLOUD-2018 Update the method to retrieve snapshot content on demand

### DIFF
--- a/src/lib/service/high5/space/event/stream/design/snapshot/index.ts
+++ b/src/lib/service/high5/space/event/stream/design/snapshot/index.ts
@@ -11,8 +11,11 @@ export default class High5DesignSnapshots extends Base {
      * @param spaceName Name of the space
      * @param eventName Name of the event
      * @param streamId ID of the stream
+     * @param content (optional) Is it necessary to retrieve content for each snapshot (disabled by default)
      * @param filters Search filters to apply
      * @param sorting Sorting criteria for the result
+     * @param limit (optional) Max number of results (1-100; defaults to 25)
+     * @param page (optional) Page number: Skip the first (page * limit) results (defaults to 0)
      * @returns Object containing an array of snapshots of the stream design and the total number of results found in the database (independent of limit and page)
      */
     public search = async (
@@ -20,6 +23,7 @@ export default class High5DesignSnapshots extends Base {
         spaceName: string,
         eventName: string,
         streamId: string,
+        content = false,
         { filters, sorting, limit = 25, page = 0 }: SearchParams
     ): Promise<PaginatedResponse<DesignSnapshot>> => {
         const filtersDTO = filters?.map((f: SearchFilter) => {
@@ -33,7 +37,7 @@ export default class High5DesignSnapshots extends Base {
                 sorting,
             },
             {
-                params: { limit, page },
+                params: { content, limit, page },
             }
         );
 


### PR DESCRIPTION
Linked task: [Exclude content from Snapshot DTO unless requested using ?content=true](https://app.clickup.com/t/86bxagk7h?utm_source=email-notifications&utm_type=1&utm_field=assignee_add).
Changes in High5: [#239](https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/239).
