### PR TITLE
HCLOUD-1950_Space-permissions-high5--fuse-must-live-in-their-own-collection-and-be-searchable-on-demand_Artur-Grafov

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.96
+
+-   **BREAKING**: Add/refactor endpoints to add/update/remove space permissions (SpacePermissions are not part of the space object anymore, but live in their own collection)
+
 ## 0.0.95
 
 -   **BREAKING**: Remove duplicate StreamNodeSpecification interface and align the remaining one (interfaces/high5/wave/index.ts) with the one defined in wave-engine

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.95",
+    "version": "0.0.96",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/fuse/space/index.ts
+++ b/src/lib/interfaces/fuse/space/index.ts
@@ -1,4 +1,5 @@
-import { Space, SpaceEntity } from "../../global";
+import { ReducedSpace, Space, SpaceEntity } from "../../global";
+import { ReducedOrganization } from "../../idp";
 
 type ExtendWith<T1, T2> = T1 & T2;
 
@@ -7,6 +8,15 @@ export interface FuseSpace extends Space {
 }
 export interface FuseSpaceEntityPermission {
     entityId: string;
+    type: SpaceEntity;
+    permission: FuseSpacePermission;
+}
+
+export interface FuseSpaceEntityPermission {
+    organization: ReducedOrganization;
+    space: ReducedSpace;
+    entityId: string;
+    entityName: string;
     type: SpaceEntity;
     permission: FuseSpacePermission;
 }

--- a/src/lib/interfaces/global/Space.ts
+++ b/src/lib/interfaces/global/Space.ts
@@ -1,31 +1,6 @@
 import { ReducedOrganization } from "../idp/organization";
 import { ReducedUser } from "../idp/user";
 
-export enum SpacePermission {
-    NONE = "NONE",
-    READ = "READ",
-    EXECUTE = "EXECUTE",
-    WRITE = "WRITE",
-    MANAGE = "MANAGE",
-    OWNER = "OWNER",
-}
-export interface SpaceEntityPermission {
-    orgId: string;
-    spaceId: string;
-    entityId: string;
-    type: SpaceEntity;
-    permission: SpacePermission;
-}
-
-export interface SpacePermissionResponse {
-    organization: ReducedOrganization;
-    space: ReducedSpace;
-    entityId: string;
-    entityName: string;
-    type: SpaceEntity;
-    permission: SpacePermission;
-}
-
 export interface Space {
     _id: string;
     name: string;

--- a/src/lib/interfaces/high5/space/index.ts
+++ b/src/lib/interfaces/high5/space/index.ts
@@ -1,4 +1,5 @@
-import { Space, SpaceEntity } from "../../global";
+import { ReducedSpace, Space, SpaceEntity } from "../../global";
+import { ReducedOrganization } from "../../idp";
 
 type ExtendWith<T1, T2> = T1 & T2;
 
@@ -7,7 +8,10 @@ export interface High5Space extends Space {
     waveEngine: string;
 }
 export interface High5SpaceEntityPermission {
+    organization: ReducedOrganization;
+    space: ReducedSpace;
     entityId: string;
+    entityName: string;
     type: SpaceEntity;
     permission: High5SpacePermission;
 }

--- a/src/lib/service/fuse/space/index.ts
+++ b/src/lib/service/fuse/space/index.ts
@@ -1,10 +1,14 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../Base";
-import { PaginatedResponse, SearchFilter, SearchParams, SpaceEntityPermission, SpacePermissionResponse } from "../../../interfaces/global";
+import { PaginatedResponse, SearchFilter, SearchParams } from "../../../interfaces/global";
 import { SearchFilterDTO } from "../../../helper/searchFilter";
 import { createPaginatedResponse } from "../../../helper/paginatedResponseHelper";
 import { FuseCronjob } from "./cronjob";
-import { FuseSpace as IFuseSpace, FuseSpacePermission as SpacePermission } from "../../../interfaces/fuse/space";
+import {
+    FuseSpaceEntityPermission as SpaceEntityPermission,
+    FuseSpace as IFuseSpace,
+    FuseSpacePermission as SpacePermission,
+} from "../../../interfaces/fuse/space";
 
 export class FuseSpace extends Base {
     public cronjob: FuseCronjob;
@@ -48,20 +52,20 @@ export class FuseSpace extends Base {
     };
 
     /**
-     * Updates the permission a user has in the specified space
+     * Adds/Updates/Removes the permission a user has in the specified space.
      * @param orgName Name of the organization
      * @param spaceName Name of the space
      * @param userId ID of the user
      * @param permission New permission
      * @returns The Fuse space with the updated permissions
      */
-    public patchUserSpacePermission = async (
+    public updateUserSpacePermission = async (
         orgName: string,
         spaceName: string,
         userId: string,
         permission: SpacePermission
     ): Promise<SpaceEntityPermission> => {
-        const resp = await this.axios.patch<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/user`), {
+        const resp = await this.axios.put<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/user`), {
             userId,
             permission,
         });
@@ -70,20 +74,20 @@ export class FuseSpace extends Base {
     };
 
     /**
-     * Updates the permission a team has in the specified space. Note: A team cannot be an owner of a Space.
+     * Adds/Updates/Removes the permission a team has in the specified space. Note: A team cannot be an owner of a Space.
      * @param orgName Name of the organization
      * @param spaceName Name of the space
      * @param teamName Name of the team
      * @param permission New permission
      * @returns The Fuse space with the updated permissions
      */
-    public patchTeamSpacePermission = async (
+    public updateTeamSpacePermission = async (
         orgName: string,
         spaceName: string,
         teamName: string,
         permission: SpacePermission
     ): Promise<SpaceEntityPermission> => {
-        const resp = await this.axios.patch<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/team`), {
+        const resp = await this.axios.put<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/team`), {
             teamName,
             permission,
         });
@@ -120,8 +124,7 @@ export class FuseSpace extends Base {
     };
 
     /**
-     * Retrieves Permissions of a space inside an Organization matching the search filter(s). Will return all Permissions if no search filter is provided
-     * and user has enough rights to see them, an empty array otherwise.
+     * Retrieves permissions of a space matching the search filter(s). Will return all permissions of the space if no search filter is provided.
      * @param orgName Name of the organization
      * @param spaceName Name of the space
      * @param filters (optional) Array of search filters
@@ -137,10 +140,10 @@ export class FuseSpace extends Base {
         sorting,
         limit = 25,
         page = 0,
-    }: SearchParams & { orgName: string; spaceName: string }): Promise<PaginatedResponse<SpacePermissionResponse>> => {
+    }: SearchParams & { orgName: string; spaceName: string }): Promise<PaginatedResponse<SpaceEntityPermission>> => {
         const filtersDTO = filters?.map((f: SearchFilter) => new SearchFilterDTO(f));
 
-        const resp = await this.axios.post<SpacePermissionResponse[]>(
+        const resp = await this.axios.post<SpaceEntityPermission[]>(
             this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permissions/search?page=${page}&limit=${limit}`),
             {
                 filters: filtersDTO,
@@ -148,7 +151,7 @@ export class FuseSpace extends Base {
             }
         );
 
-        return createPaginatedResponse(resp) as PaginatedResponse<SpacePermissionResponse>;
+        return createPaginatedResponse(resp) as PaginatedResponse<SpaceEntityPermission>;
     };
 
     /**

--- a/src/lib/service/high5/space/index.ts
+++ b/src/lib/service/high5/space/index.ts
@@ -1,7 +1,11 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../Base";
-import { High5Space as Space, High5SpacePermission as SpacePermission} from "../../../interfaces/high5/space";
-import { PaginatedResponse, SearchFilter, SearchParams, SpacePermissionResponse } from "../../../interfaces/global";
+import {
+    High5SpaceEntityPermission as SpaceEntityPermission,
+    High5Space as Space,
+    High5SpacePermission as SpacePermission,
+} from "../../../interfaces/high5/space";
+import { PaginatedResponse, SearchFilter, SearchParams } from "../../../interfaces/global";
 import { SearchFilterDTO } from "../../../helper/searchFilter";
 import { createPaginatedResponse } from "../../../helper/paginatedResponseHelper";
 import { High5Event } from "./event";
@@ -57,8 +61,7 @@ export class High5Space extends Base {
     };
 
     /**
-     * Retrieves Permissions of a space inside an Organization matching the search filter(s). Will return all Permissions if no search filter is provided
-     * and user has enough rights to see them, an empty array otherwise.
+     * Retrieves permissions of a space matching the search filter(s). Will return all permissions of the space if no search filter is provided.
      * @param orgName Name of the organization
      * @param spaceName Name of the space
      * @param filters (optional) Array of search filters
@@ -74,10 +77,10 @@ export class High5Space extends Base {
         sorting,
         limit = 25,
         page = 0,
-    }: SearchParams & { orgName: string; spaceName: string }): Promise<PaginatedResponse<SpacePermissionResponse>> => {
+    }: SearchParams & { orgName: string; spaceName: string }): Promise<PaginatedResponse<SpaceEntityPermission>> => {
         const filtersDTO = filters?.map((f: SearchFilter) => new SearchFilterDTO(f));
 
-        const resp = await this.axios.post<SpacePermissionResponse[]>(
+        const resp = await this.axios.post<SpaceEntityPermission[]>(
             this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permissions/search?page=${page}&limit=${limit}`),
             {
                 filters: filtersDTO,
@@ -85,7 +88,7 @@ export class High5Space extends Base {
             }
         );
 
-        return createPaginatedResponse(resp) as PaginatedResponse<SpacePermissionResponse>;
+        return createPaginatedResponse(resp) as PaginatedResponse<SpaceEntityPermission>;
     };
 
     /**
@@ -122,20 +125,20 @@ export class High5Space extends Base {
     };
 
     /**
-     * Updates the permission a User has in the specified High5 Space.
+     * Adds/Updates/Removes the permission a user has in the specified space.
      * @param orgName Name of the Organization
      * @param spaceName Name of the Space
      * @param userId ID of the User
      * @param permission New permission
      * @returns The Space with updated permissions
      */
-    public patchUserSpacePermission = async (
+    public updateUserSpacePermission = async (
         orgName: string,
         spaceName: string,
         userId: string,
         permission: SpacePermission
-    ): Promise<SpacePermissionResponse> => {
-        const resp = await this.axios.patch<SpacePermissionResponse>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/user`), {
+    ): Promise<SpaceEntityPermission> => {
+        const resp = await this.axios.put<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/user`), {
             userId,
             permission,
         });
@@ -144,20 +147,20 @@ export class High5Space extends Base {
     };
 
     /**
-     * Updates the permission a Team has in the specified High5 Space.
+     * Adds/Updates/Removes the permission a team has in the specified space. Note: A team cannot be an owner of a Space.
      * @param orgName Name of the Organization
      * @param spaceName Name of the Space
      * @param teamName Name of the Team
      * @param permission New permission
      * @returns The Space with updated permissions
      */
-    public patchTeamSpacePermission = async (
+    public updateTeamSpacePermission = async (
         orgName: string,
         spaceName: string,
         teamName: string,
         permission: SpacePermission
-    ): Promise<SpacePermissionResponse> => {
-        const resp = await this.axios.patch<SpacePermissionResponse>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/team`), {
+    ): Promise<SpaceEntityPermission> => {
+        const resp = await this.axios.put<SpaceEntityPermission>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/permission/team`), {
             teamName,
             permission,
         });


### PR DESCRIPTION
Update SpacePermission interfaces and add the new search SpacePermissions Endpoint

backend-core: https://github.com/moovit-sp-gmbh/backend-core/pull/76
High5: https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/243
Fuse: https://github.com/moovit-sp-gmbh/hcloud-fuse-backend/pull/110