### PR TITLE
HCLOUD-1885_Expose-the-node-specification-in-the-SDK_Darius-Weiberg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.95
+
+-   **BREAKING**: Remove duplicate StreamNodeSpecification interface and align the remaining one (interfaces/high5/wave/index.ts) with the one defined in wave-engine
+
 ## 0.0.94
 
 -   Add endpoint to resend organization invitation email

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hcloud-sdk",
-    "version": "0.0.94",
+    "version": "0.0.95",
     "description": "hcloud platform sdk",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/lib/interfaces/high5/space/event/stream/design/StreamNodeSpecification.ts
+++ b/src/lib/interfaces/high5/space/event/stream/design/StreamNodeSpecification.ts
@@ -1,20 +1,3 @@
-export interface StreamNodeSpecification {
-    name: string;
-    description: string;
-    type: StreamNodeSpecificationType;
-    package: StreamNodeSpecificationPackage;
-    category: StreamNodeSpecificationCategory;
-    version: StreamSemanticVersion;
-    author: StreamNodeSpecificationAuthor;
-    inputs?: StreamNodeSpecificationInput[];
-    outputs?: StreamNodeSpecificationOutput[];
-    additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
-    tag?: StreamNodeSpecificationTag;
-    requireSdk?: boolean;
-    path: string;
-    customNode?: StreamCustomNodeSpecification;
-}
-
 export interface StreamCustomNodeSpecification {
     _id: string;
 }

--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -63,9 +63,8 @@ export interface StreamNodeSpecification {
     package: StreamNodeSpecificationPackage;
     category: StreamNodeSpecificationCategory;
     version: StreamSemanticVersion;
-    tag?: StreamNodeSpecificationTag;
     author: StreamNodeSpecificationAuthor;
-    deprecated?: boolean;
+    tag?: StreamNodeSpecificationTag;
     requireSdk?: boolean;
     inputs?: StreamNodeSpecificationInput[];
     outputs?: StreamNodeSpecificationOutput[];
@@ -141,7 +140,6 @@ export enum StreamNodeSpecificationType {
 }
 
 export enum StreamNodeSpecificationTag {
-    DEPRECATED = "DEPRECATED",
     PREVIEW = "PREVIEW",
     EXPERIMENTAL = "EXPERIMENTAL",
 }


### PR DESCRIPTION
Refactor: remove duplicate StreamNodeSpecification interface and align the remaining one with the one defined in wave-engine

wave-nodes: https://github.com/moovit-sp-gmbh/wave-nodes/pull/8
wave-engine: https://github.com/moovit-sp-gmbh/wave-engine/pull/17