### PR TITLE
Hcloud 2323 extend node output types jorge brown

### DIFF
--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -112,13 +112,27 @@ export interface StreamNodeSpecificationInput {
     mandatory?: boolean;
 }
 
-export interface StreamNodeSpecificationOutput {
+export type PrimitiveOutput = {
+    type: Exclude<
+        StreamNodeSpecificationInputOutputType,
+        StreamNodeSpecificationInputOutputType.OBJECT | StreamNodeSpecificationInputOutputType.LIST
+    >;
+};
+export type ObjectOutput = {
+    type: StreamNodeSpecificationInputOutputType.OBJECT;
+    shape?: StreamNodeSpecificationOutput[];
+};
+export type ListOutput = {
+    type: StreamNodeSpecificationInputOutputType.LIST;
+    elemType?: PrimitiveOutput | ObjectOutput | ListOutput;
+};
+
+export type StreamNodeSpecificationOutput = {
     name: string;
     description: string;
-    type: StreamNodeSpecificationInputOutputType;
     example: any;
     howToAccess: string[];
-}
+} & (PrimitiveOutput | ObjectOutput | ListOutput);
 
 export enum StreamNodeSpecificationInputOutputType {
     STRING = "STRING",


### PR DESCRIPTION
style: apply formatting

feat: add OBJECT and LIST to node spec i/o type

feat: add more node output types

The node output types are now split into Primitive, Object and List.
- Primitive type is the same as before
- Object type has an optional shape property to define the shape of the
  object
- List type has an elemType property to specify the type of its
  elements. This type can be Primitive, Object or List(matrices).

Example { File_Path: string }[]:
```ts
{
    name: "Files",
    description: "Results for the files",
    type: StreamNodeSpecificationInputOutputType.LIST,
    elemType: {
        type: StreamNodeSpecificationInputOutputType.OBJECT,
        shape: [
            {
                name: Output.FILE_PATH,
                description: "...",
                type: StreamNodeSpecificationInputOutputType.STRING,
                example: "...",
                howToAccess: ["{{OUTPUT.<nodeUUID>.Files[0].File_Path}}"]
            },
        ]
    },
    howToAccess: ["{{OUTPUT.<nodeUUID>.Files}}"]
}
```