### PR TITLE
HCLOUD-2056 Move get node content endpoint

### DIFF
--- a/src/lib/service/high5/space/node/index.ts
+++ b/src/lib/service/high5/space/node/index.ts
@@ -105,11 +105,13 @@ export default class High5Node extends Base {
 
     /**
      * Retrieves the content (raw javascript code) of a Node.
+     * @param orgName Name of the organization
+     * @param spaceName Name of the space
      * @param secret Secret of the Node (a unique sha512 hash)
-     * @returns Raw javascript representation of the Node's content
+     * @rerurns Raw javascript representation of the Node's content
      */
-    public async getNodeContent(secret: string): Promise<string> {
-        const resp = await this.axios.get<string>(this.getEndpoint(`/v1/org/nodes/content/${secret}`));
+    public async getNodeContent(orgName: string, spaceName: string, secret: string): Promise<string> {
+        const resp = await this.axios.get<string>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/nodes/content/${secret}`));
 
         return resp.data;
     }


### PR DESCRIPTION
Linked task: [Move get node content endpoint](https://app.clickup.com/t/86bxduh0n?utm_source=email-notifications&utm_type=1&utm_field=assignee_add).

This reverts commit 28c5403217358e77634cf574d0cd0fb30cdc30cb.

Endpoint should validate org and space names for security purposes
Related PR: [#270](https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/270).
