### PR TITLE
HCLOUD-2381_Extend-the-response-of-the-apihigh5v1orgOrgNameexecutionstatussearchpage0limit25-to-include-the-reduced-event-object_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -1,6 +1,7 @@
 import { ReducedSpace } from "../../../global";
 import { ReducedOrganization, ReducedUser } from "../../../idp";
 import { WaveCatalog, WaveEngine } from "../../wave";
+import { ReducedEvent } from "../event";
 import { DesignBuild } from "../event/stream";
 import { StreamSingleNodeResult } from "../event/stream/node";
 
@@ -83,6 +84,7 @@ export interface High5ExecutionStatus {
     _id: string;
     organization: ReducedOrganization;
     space: ReducedSpace;
+    event: ReducedEvent;
     streamId: string;
     streamName: string;
     high5ExecutionId: string;


### PR DESCRIPTION
feat: add reducedEvent prop to execution status interface