### PR TITLE
HCLOUD-2406_find-a-way-to-provide-hcl-client-in-wave-engine_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -1,3 +1,4 @@
+import { HCloud } from "../../../../Hcloud";
 import { ReducedSpace } from "../../../global";
 import { ReducedOrganization, ReducedUser } from "../../../idp";
 import { WaveCatalog, WaveEngine } from "../../wave";
@@ -61,6 +62,9 @@ export interface High5ExecutionPackage {
     dry: boolean;
 }
 
+export interface ExtendedHigh5ExecutionPackage extends High5ExecutionPackage {
+    hcl: HCloud;
+}
 export interface High5ExecutionPatchLog {
     streamId: string;
     nodeResults: StreamSingleNodeResult[];


### PR DESCRIPTION
feat: extend execution package by hcloud client instance