### PR TITLE
HCLOUD-2484 Remove endpoint to search execution statuses

### DIFF
--- a/src/lib/Hcloud.ts
+++ b/src/lib/Hcloud.ts
@@ -1,18 +1,18 @@
-import axios, { AxiosInstance } from "axios"
-import { version } from "../package.json"
-import { HcloudLogger, Options } from "./Base"
-import wrapError from "./helper/ErrorHelper"
-import { disableCacheHeaders } from "./interfaces/axios"
-import AgentService from "./service/agent"
-import AuditorService from "./service/auditor"
-import BouncerService from "./service/bouncer"
-import DaliService from "./service/dali"
-import FuseService from "./service/fuse"
-import High5Service from "./service/high5"
-import IdpService from "./service/idp"
-import MailerService from "./service/mailer"
-import MothershipService from "./service/mothership"
-import NatsService from "./service/nats"
+import axios, { AxiosInstance } from "axios";
+import { version } from "../package.json";
+import { HcloudLogger, Options } from "./Base";
+import wrapError from "./helper/ErrorHelper";
+import { disableCacheHeaders } from "./interfaces/axios";
+import AgentService from "./service/agent";
+import AuditorService from "./service/auditor";
+import BouncerService from "./service/bouncer";
+import DaliService from "./service/dali";
+import FuseService from "./service/fuse";
+import High5Service from "./service/high5";
+import IdpService from "./service/idp";
+import MailerService from "./service/mailer";
+import MothershipService from "./service/mothership";
+import NatsService from "./service/nats";
 
 // tslint:disable-next-line
 export class HCloud {

--- a/src/lib/service/agent/bundle/index.ts
+++ b/src/lib/service/agent/bundle/index.ts
@@ -1,7 +1,7 @@
-import { AxiosInstance } from "axios"
-import Base, { Options } from "../../../Base"
-import { AgentVersions, Version } from "../../../interfaces/agent"
-import { disableCacheHeaders } from "../../../interfaces/axios"
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../Base";
+import { AgentVersions, Version } from "../../../interfaces/agent";
+import { disableCacheHeaders } from "../../../interfaces/axios";
 
 export class AgentBundle extends Base {
     private sourceServer: string;

--- a/src/lib/service/agent/installer/index.ts
+++ b/src/lib/service/agent/installer/index.ts
@@ -1,7 +1,7 @@
-import { AxiosInstance } from "axios"
-import Base, { Options } from "../../../Base"
-import { AgentInstallerVersions, InstallerVersion } from "../../../interfaces/agent"
-import { disableCacheHeaders } from "../../../interfaces/axios"
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../Base";
+import { AgentInstallerVersions, InstallerVersion } from "../../../interfaces/agent";
+import { disableCacheHeaders } from "../../../interfaces/axios";
 
 export class AgentInstaller extends Base {
     private sourceServer: string;

--- a/src/lib/service/high5/space/execution/status/index.ts
+++ b/src/lib/service/high5/space/execution/status/index.ts
@@ -1,8 +1,7 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../../Base";
 import { High5ExecutionStatus } from "../../../../../interfaces/high5/space/execution";
-import { PaginatedResponse, SearchFilter, SearchParams } from "../../../../../interfaces/global";
-import { SearchFilterDTO } from "../../../../../helper/searchFilter";
+import { PaginatedResponse } from "../../../../../interfaces/global";
 import { createPaginatedResponse } from "../../../../../helper/paginatedResponseHelper";
 
 export class High5SpaceExecutionStates extends Base {

--- a/src/lib/service/high5/wave/s3/index.ts
+++ b/src/lib/service/high5/wave/s3/index.ts
@@ -1,7 +1,7 @@
-import { AxiosInstance } from "axios"
-import Base, { Options } from "../../../../Base"
-import { disableCacheHeaders } from "../../../../interfaces/axios"
-import { Catalog, CatalogRegistry, Engine, EngineRegistry, StreamNodeSpecification } from "../../../../interfaces/high5"
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../../Base";
+import { disableCacheHeaders } from "../../../../interfaces/axios";
+import { Catalog, CatalogRegistry, Engine, EngineRegistry, StreamNodeSpecification } from "../../../../interfaces/high5";
 
 /**
  * Class for reading the S3 bucket of a wave engine and catalogs


### PR DESCRIPTION
Linked task: [Remove the following endpoint - /v1/org/:orgName/spaces/:spaceName/execution/status/search](https://app.clickup.com/t/2570196/HCLOUD-2484).

Related PR [#296](https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/296).
