### PR TITLE
HCLOUD-2538_Extend-the-Wave-engine-Node-catalog-and-agent-bundle-implementation-to-support-both-development-and-production-releases_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -19,6 +19,7 @@ export interface WaveEngine {
     url: string;
     changeLog: string[];
     md5: string;
+    dev?: boolean;
 }
 
 export interface WaveCatalog {
@@ -26,6 +27,7 @@ export interface WaveCatalog {
     version: string;
     url: string;
     changeLog: string[];
+    dev?: boolean;
 }
 
 export interface Engine {


### PR DESCRIPTION
feat: add dev boolean flag to catalog and engine version