### PR TITLE
HCLOUD-2569 Add canvas dimensions to the design object

### DIFF
--- a/src/lib/interfaces/high5/space/event/stream/design/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/design/index.ts
@@ -4,6 +4,11 @@ import { ReducedOrganization } from "../../../../../idp/organization";
 import { ReducedUser } from "../../../../../idp/user";
 import { DesignContent } from "./StreamDesign";
 
+export interface CanvasDimensions {
+    width: number;
+    height: number;
+}
+
 export interface Design {
     _id: string;
     name: string;
@@ -15,6 +20,7 @@ export interface Design {
     organization: ReducedOrganization;
     creator: ReducedUser;
     designHash: string;
+    canvas: CanvasDimensions;
     /**
      * UTC+0 unix timestamp
      */

--- a/src/lib/service/high5/space/event/stream/design/index.ts
+++ b/src/lib/service/high5/space/event/stream/design/index.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../../../Base";
-import { Design } from "../../../../../../interfaces/high5/space/event/stream/design";
+import { CanvasDimensions, Design } from "../../../../../../interfaces/high5/space/event/stream/design";
 import { DesignContent } from "../../../../../../interfaces/high5/space/event/stream/design/StreamDesign";
 import DesignOperations from "./DesignOperations";
 import High5DesignSnapshots from "./snapshot";
@@ -56,6 +56,7 @@ export class High5Design extends Base {
         streamId: string,
         name: string,
         content: DesignContent,
+        canvas: CanvasDimensions,
         build?: unknown
     ): Promise<Design> => {
         const resp = await this.axios.put<Design>(
@@ -64,6 +65,7 @@ export class High5Design extends Base {
                 name,
                 content,
                 build,
+                canvas,
             }
         );
 


### PR DESCRIPTION
Linked task: [Add x and y coordinates to the SDK to enable the frontend team to build the auto-expand canvas feature in SDS](https://app.clickup.com/t/2570196/HCLOUD-2569).

Related changes in [High5 backend](https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/319).
