### PR TITLE
HCLOUD-2672_Agent-014-2619bce-throws-reader-closed-SyntaxError-Unexpected-end-of-JSON-input-at-the-start_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/nats/index.ts
+++ b/src/lib/interfaces/nats/index.ts
@@ -137,7 +137,7 @@ interface NatsExecTargetObject extends NatsMemberObject {
 interface NatsSecretObject {
     secretKey: string;
 }
-type NatsCallback = (msg: NatsMessage, rawMsg: Msg) => void;
+type NatsCallback = (err: Error | null, msg?: NatsMessage, rawMsg?: Msg) => void;
 
 /**
  * NatsSubjects creates subject strings to be used with nats.subscribe and nats.publish

--- a/src/lib/service/nats/index.ts
+++ b/src/lib/service/nats/index.ts
@@ -95,8 +95,29 @@ class Nats extends Base {
             const newOptions = {
                 ...options,
                 callback: (err: NatsError | null, msg: Msg) => {
-                    const data = new TextDecoder("utf-8").decode(msg.data);
-                    callback(JSON.parse(data) as NatsMessage, msg);
+                    if (err !== null) {
+                        try {
+                            callback(err);
+                        } catch (ignored) {
+                            // ignore callback errors
+                        }
+                        return;
+                    }
+
+                    let parsedData: NatsMessage;
+                    try {
+                        const data = new TextDecoder("utf-8").decode(msg.data);
+                        parsedData = JSON.parse(data);
+                    } catch (e) {
+                        callback(e as Error);
+                        return;
+                    }
+
+                    try {
+                        callback(null, parsedData, msg);
+                    } catch (ignored) {
+                        // ignore callback errors
+                    }
                 },
             };
 


### PR DESCRIPTION
Pass on the error in the Nats Callback

# Related PRs

- https://github.com/moovit-sp-gmbh/hcloud-agent/pull/102
- https://github.com/moovit-sp-gmbh/hcloud-sdk-js/pull/187