### PR TITLE
HCLOUD-2537_Investigate-what-needs-to-be-implemented-to-ensure-that-any-errors-occurring-during-the-execution-of-a-node-or-stream-are-consistently-forwarded-to-the-stream-debugger_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -68,6 +68,7 @@ export interface ExtendedHigh5ExecutionPackage extends High5ExecutionPackage {
     orgName: string;
     spaceName: string;
     streamId: string;
+    secret: string;
 }
 
 export interface High5ExecutionPatchLog {


### PR DESCRIPTION
feat: add secret to the extended exec package
    
    It's needed to report an unhandled rejection that is async takes place after
    the whole stream got finished. In that case it's reported as successful but
    the exception comes after stream got finished. As the execution state helper
    already closed the report intervall of the status we need to do the http request
    from within the engine. Therefore we need the secret to call the report endpoint.