### PR TITLE
HCLOUD-2655_Remove-the-documentation-property-from-the-wave-node-spec_Darius-Weiberg

### DIFF
--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -89,6 +89,27 @@ export function isStreamNodeSpecificationV1(s: StreamNodeSpecification): s is St
     return s.specVersion === 1;
 }
 
+export interface StreamNodeSpecificationV2 extends StreamNodeSpecification {
+    specVersion: 2;
+    name: string;
+    description: string;
+    type: StreamNodeSpecificationType;
+    package: StreamNodeSpecificationPackage;
+    category: string;
+    version: StreamSemanticVersion;
+    author: StreamNodeSpecificationAuthor;
+    tag?: StreamNodeSpecificationTag;
+    requireSdk?: boolean;
+    inputs?: StreamNodeSpecificationInput[];
+    outputs?: StreamNodeSpecificationOutput[];
+    additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
+    path?: string;
+    customNode?: StreamCustomNodeSpecification;
+}
+export function isStreamNodeSpecificationV2(s: StreamNodeSpecification): s is StreamNodeSpecificationV2 {
+    return s.specVersion === 2;
+}
+
 export interface StreamCustomNodeSpecification {
     _id: string;
     color?: string;


### PR DESCRIPTION
Add StreamNodeSpecificationV2 (has no 'documentation' property anymore)