### PR TITLE
HCLOUD-2801_Update-email-template-with-receiver_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/mailer/index.ts
+++ b/src/lib/interfaces/mailer/index.ts
@@ -69,9 +69,9 @@ export class IdpNewRegistrationMailjetMailDTO extends MailjetMailDTO {
 }
 
 export class IdpNewRegistrationMailjetMailToCustomerDTO extends MailjetMailDTO {
-    constructor(recipients: string[], email: string) {
+    constructor(recipients: string[], username: string) {
         super(recipients, MailjetTemplate.IDP_NEW_REGISTRATION_CUSTOMER, {
-            EMAIL_TO: email,
+            USERNAME: username,
         });
     }
 }

--- a/src/lib/service/idp/oauth/index.ts
+++ b/src/lib/service/idp/oauth/index.ts
@@ -1,6 +1,6 @@
-import { AxiosInstance } from "axios"
-import Base, { Options } from "../../../Base"
-import { OAuthToken, OAuthTokenRequest } from "../../../interfaces/idp/oauth"
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../Base";
+import { OAuthToken, OAuthTokenRequest } from "../../../interfaces/idp/oauth";
 
 export class IdpOAuth extends Base {
     constructor(options: Options, axios: AxiosInstance) {


### PR DESCRIPTION
fix: use name rather than email in registration mail send to user