### PR TITLE
HCLOUD-3001_make-lastUrllastView-patching-its-own-endpoint-one-in-total-for-both-that-does-NOT-send-nats-updates_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/idp/user/GeneralSettings.ts
+++ b/src/lib/interfaces/idp/user/GeneralSettings.ts
@@ -49,3 +49,5 @@ export interface GeneralSettings {
 }
 
 export type GeneralSettingsPatch = Partial<Omit<GeneralSettings, "_id" | "user">>;
+
+export type GeneralSettingsLastVisitPatch = Partial<Pick<GeneralSettings, "lastUrl" | "lastView">>;

--- a/src/lib/service/idp/user/settings/general/index.ts
+++ b/src/lib/service/idp/user/settings/general/index.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from "axios";
 import Base, { Options } from "../../../../../Base";
-import { GeneralSettings, GeneralSettingsPatch } from "../../../../../interfaces/idp/user/GeneralSettings";
+import { GeneralSettings, GeneralSettingsLastVisitPatch, GeneralSettingsPatch } from "../../../../../interfaces/idp/user/GeneralSettings";
 
 export class IdpGeneral extends Base {
     constructor(options: Options, axios: AxiosInstance) {
@@ -24,6 +24,17 @@ export class IdpGeneral extends Base {
      */
     public patchGeneralSettings = async (generalSettingsPatch: GeneralSettingsPatch): Promise<GeneralSettings> => {
         const resp = await this.axios.patch<GeneralSettings>(this.getEndpoint(`/v1/user/settings/general`), generalSettingsPatch);
+
+        return resp.data;
+    };
+
+    /**
+     * Changes the user last visit settings.
+     * @param generalSettingsLastVisitPatch Object containing the new user settings in case of lastView and lastURL
+     * @returns the updated user settings
+     */
+    public patchGeneralSettingsLastVisit = async (generalSettingsLastVisitPatch: GeneralSettingsLastVisitPatch): Promise<GeneralSettings> => {
+        const resp = await this.axios.patch<GeneralSettings>(this.getEndpoint(`/v1/user/settings/general/lastVisit`), generalSettingsLastVisitPatch);
 
         return resp.data;
     };


### PR DESCRIPTION
feat: add dedicated endpoint for separate lastURL, lastView update