### PR TITLE
HCLOUD-2939_Stream-result-should-include-node-inputs-in-case-the-node-fails_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/space/event/stream/node/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/node/index.ts
@@ -30,6 +30,8 @@ export interface StreamNodeResolvedInputs {
     originalValue: unknown;
     value: unknown;
     type: StreamNodeSpecificationInputType;
+    error: boolean;
+    errorMessage: string;
 }
 
 export interface StreamNodeOutput {

--- a/src/lib/utils/bouncer/features/Provider.ts
+++ b/src/lib/utils/bouncer/features/Provider.ts
@@ -1,4 +1,4 @@
-import { BouncerContext, HcloudFeature } from "../../../interfaces/bouncer"
+import { BouncerContext, HcloudFeature } from "../../../interfaces/bouncer";
 
 export type BouncerProviderLogger = (
     featureName: string,


### PR DESCRIPTION
feat: add node input error properties
