### PR TITLE
HCLOUD-3103_Used-catalogs-are-not-derived-from-published-design_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -1,7 +1,7 @@
 import { HCloud } from "../../../../Hcloud";
 import { ReducedSpace } from "../../../global";
 import { ReducedOrganization, ReducedUser } from "../../../idp";
-import { WaveCatalog, WaveEngine } from "../../wave";
+import { ReducedWaveCatalog, WaveCatalog, WaveEngine } from "../../wave";
 import { ReducedEvent } from "../event";
 import { DesignBuild } from "../event/stream";
 import { StreamNodeAdditionalConnector, StreamNodeOutput, StreamNodeResolvedInputs, StreamSingleNodeResult } from "../event/stream/node";
@@ -58,7 +58,7 @@ export interface EventExecutionResult {
 export interface High5ExecutionPackage {
     design: DesignBuild;
     payload: High5ExecutionPayload;
-    waveCatalogs: WaveCatalog[];
+    waveCatalogs: ReducedWaveCatalog[];
     waveEngine: WaveEngine;
     dry: boolean;
     info: StreamInfo;

--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -28,6 +28,11 @@ export interface WaveEngine {
     latest?: boolean;
 }
 
+export interface ReducedWaveCatalog {
+    version: string;
+    url: string;
+}
+
 export interface WaveCatalog {
     _id: string;
     version: string;


### PR DESCRIPTION
BREAKING CHANGE: kept only the url and version properties