### PR TITLE
HCLOUD-3073_Extend-stream-execution-logs_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/high5/space/event/stream/node/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/node/index.ts
@@ -52,7 +52,7 @@ export interface StreamSingleNodeResult {
     nodeUuid: string;
     failed: boolean;
     startTimestamp: number;
-    endTimestamp: number;
+    endTimestamp?: number;
     name: string;
     inputs?: StreamNodeResolvedInputs[];
     outputs?: StreamNodeOutput[];


### PR DESCRIPTION
Nodes with no endTimestamp are currently running

Related PRs:
- Engine: https://github.com/moovit-sp-gmbh/wave-engine/pull/95
- High5: https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/414
- SDK: https://github.com/moovit-sp-gmbh/hcloud-sdk-js/pull/236