### PR TITLE
HCLOUD-3148_Add-support-for-breakpoints-backend_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/high5/execution/index.ts
+++ b/src/lib/interfaces/high5/execution/index.ts
@@ -1,0 +1,24 @@
+export type DebugCommand = ContinueDebugCommand | StepBackDebugCommand | StepForwardDebugCommand | SetValueDebugCommand;
+
+export enum CommandType {
+    CONTINUE = "CONTINUE",
+    STEP_BACK = "STEP_BACK",
+    STEP_FORWARD = "STEP_FORWARD",
+    SET_VALUE = "SET_VALUE",
+}
+
+export type ContinueDebugCommand = {
+    type: CommandType.CONTINUE;
+};
+export type StepBackDebugCommand = {
+    type: CommandType.STEP_BACK;
+};
+export type StepForwardDebugCommand = {
+    type: CommandType.STEP_FORWARD;
+};
+export type SetValueDebugCommand = {
+    type: CommandType.SET_VALUE;
+    uuid: string;
+    key: string;
+    value: unknown;
+};

--- a/src/lib/interfaces/high5/index.ts
+++ b/src/lib/interfaces/high5/index.ts
@@ -13,3 +13,4 @@ export * from "./space/webhook";
 export * from "./space/secret";
 export * from "./joinToken";
 export * from "./space/pool";
+export * from "./execution/";

--- a/src/lib/interfaces/high5/space/event/stream/design/StreamDesign.ts
+++ b/src/lib/interfaces/high5/space/event/stream/design/StreamDesign.ts
@@ -27,6 +27,7 @@ export interface DesignerNode {
     path: string;
     catalog: DesignerNodeCatalog;
     customNode?: StreamCustomNodeSpecification; // customNodes are being created within the Stream Designer and are not part of the default NodeCatalogue
+    breakpoint?: boolean;
 }
 
 export interface DesignerNodeCatalog {

--- a/src/lib/interfaces/high5/space/event/stream/node/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/node/index.ts
@@ -62,6 +62,7 @@ export interface StreamSingleNodeResult {
     bypassed?: boolean;
     nodeResults?: StreamSingleNodeResult[];
     info?: NodeInfo;
+    waiting?: boolean;
 }
 
 type NodeInfo = {

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -154,6 +154,7 @@ export interface StreamNode {
     inputs?: StreamNodeResolvedInputs[];
     outputs?: StreamNodeOutput[];
     additionalConnectors?: StreamNodeAdditionalConnector[];
+    breakpoint?: boolean;
 }
 
 export interface High5ExecuteOnAgentRequest {

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -85,6 +85,7 @@ export interface ExtendedHigh5ExecutionPackage extends High5ExecutionPackage {
 export interface High5ExecutionPatchLog {
     streamId: string;
     nodeResults: StreamSingleNodeResult[];
+    nodeResultsToRemove?: string[];
 }
 
 export interface StreamRunningNodePatch {

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -62,6 +62,7 @@ export interface High5ExecutionPackage {
     waveEngine: WaveEngine;
     dry: boolean;
     info: StreamInfo;
+    debug: boolean;
 }
 
 type StreamInfo = {

--- a/src/lib/interfaces/nats/index.ts
+++ b/src/lib/interfaces/nats/index.ts
@@ -27,6 +27,8 @@ enum NatsSubject {
     HIGH5_SPACE_PERMISSIONS = "hcloud.high5.organization.${base64orgName}.spaces.${base64spaceName}.permissions",
     HIGH5_STREAM_EXECUTE = "hcloud.high5.organization.${organizationId}.stream.execute.${base64email}",
     HIGH5_STREAM_CANCEL = "hcloud.high5.organization.${organizationId}.stream.execute.${base64email}", // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
+    HIGH5_STREAM_DEBUG_STOPPED = "hcloud.high5.organization.${organizationId}.stream.execute.${base64email}.${executionId}.stopped",
+    HIGH5_STREAM_DEBUG_COMMAND = "hcloud.high5.organization.${organizationId}.stream.execute.${base64email}.${executionSecret}.command",
     HIGH5_EVENTS = "hcloud.high5.organization.${base64orgName}.spaces.${base64spaceName}.events",
     HIGH5_STREAMS = "hcloud.high5.organization.${base64orgName}.spaces.${base64spaceName}.streams",
     HIGH5_EVENT_STREAMS = "hcloud.high5.organization.${base64orgName}.spaces.${base64spaceName}.events.${base64eventName}.streams",
@@ -70,6 +72,8 @@ type NatsSubjectReplacements = {
     poolName?: string;
     poolId?: string;
     oAuthAppId?: string;
+    executionId?: string;
+    executionSecret?: string;
 };
 
 enum NatsMessageType {
@@ -322,6 +326,25 @@ class NatsSubjects {
             static CANCEL = (organizationId: string, email: string) => {
                 return NatsSubjects.replace(NatsSubject.HIGH5_STREAM_CANCEL, { organizationId, email });
             };
+
+            static DEBUG = (organizationId: string, email: string) => {
+                return {
+                    STOPPED: function (executionId: string) {
+                        return NatsSubjects.replace(NatsSubject.HIGH5_STREAM_DEBUG_STOPPED, {
+                            organizationId,
+                            email,
+                            executionId,
+                        });
+                    },
+                    COMMAND: function (executionSecret: string) {
+                        return NatsSubjects.replace(NatsSubject.HIGH5_STREAM_DEBUG_COMMAND, {
+                            organizationId,
+                            email,
+                            executionSecret,
+                        });
+                    },
+                };
+            };
         };
 
         static SPACES = (organizationName: string) => {
@@ -461,6 +484,8 @@ class NatsSubjects {
             replacements.poolName ? (replacements.poolName === "*" ? "*" : base64Encode(replacements.poolName)) : "null"
         );
         subject = subject.replace("${poolId}", replacements.poolId || "null");
+        subject = subject.replace("${executionId}", replacements.executionId || "null");
+        subject = subject.replace("${executionSecret}", replacements.executionSecret || "null");
 
         return subject;
     };

--- a/src/lib/service/high5/space/execution/index.ts
+++ b/src/lib/service/high5/space/execution/index.ts
@@ -37,11 +37,18 @@ export class High5SpaceExecute extends Base {
         spaceName: string,
         streamId: string,
         high5ExecutionRequest: High5ExecutionRequest,
-        design = false
+        design = false,
+        debug = false
     ): Promise<High5ExecutionResponse> {
         const resp = await this.axios.post<High5ExecutionResponse>(
-            this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execute/stream/id/${streamId}${design ? "?design=true" : ""}`),
-            high5ExecutionRequest
+            this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execute/stream/id/${streamId}`),
+            high5ExecutionRequest,
+            {
+                params: {
+                    design,
+                    debug,
+                },
+            }
         );
 
         return resp.data;

--- a/src/lib/service/high5/space/execution/index.ts
+++ b/src/lib/service/high5/space/execution/index.ts
@@ -1,4 +1,5 @@
 import Base from "../../../../Base";
+import { DebugCommand } from "../../../../interfaces/high5";
 import {
     High5ExecutionPackage,
     High5ExecutionPatch,
@@ -108,6 +109,23 @@ export class High5SpaceExecute extends Base {
         high5ExecutionResponse: High5ExecutionPatch
     ): Promise<void> {
         await this.axios.patch<void>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execution/streams/${secret}`), high5ExecutionResponse);
+    }
+
+    /**
+     * Issue debug command to a stopped execution running in debug mode.
+     * If the agent that is handling this execution does not acknowledge
+     * the debug command after a certain timeframe, a timeout error will
+     * be thrown.
+     *
+     * Only the user that triggered the execution can send debug commands.
+     *
+     * @param orgName      Name of the organization
+     * @param spaceName    Name of the space
+     * @param executionId  ID of the execution. Obtained from High5ExecutionResponse
+     * @param command      DebugCommand to send
+     */
+    async issueDebugCommand(orgName: string, spaceName: string, executionId: string, command: DebugCommand): Promise<void> {
+        await this.axios.post<void>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execute/${executionId}`), command);
     }
 
     protected getEndpoint(endpoint: string): string {


### PR DESCRIPTION
Related PRs:
- Agent: https://github.com/moovit-sp-gmbh/hcloud-agent/pull/158
- IDP: https://github.com/moovit-sp-gmbh/hcloud-idp-backend/pull/493
- Engine: https://github.com/moovit-sp-gmbh/wave-engine/pull/103
- High5: https://github.com/moovit-sp-gmbh/hcloud-high5-backend/pull/421
- SDK: https://github.com/moovit-sp-gmbh/hcloud-sdk-js/pull/241