### PR TITLE
HCLOUD-3150_Implement-method-to-export-wildcards-to-a-json-file-backend_Artur-Grafov

### DIFF
--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -18,6 +18,20 @@ export interface EngineRegistry {
     }[];
 }
 
+export interface Wildcard {
+    name: string;
+    description: string;
+    example: string;
+    resolved: string;
+}
+
+export interface WildcardRegistry {
+    Agent: Wildcard[];
+    Stream: Wildcard[];
+    Node: Wildcard[];
+    General: Wildcard[];
+}
+
 export interface WaveEngine {
     _id: string;
     version: string;

--- a/src/lib/interfaces/idp/organization/member/index.ts
+++ b/src/lib/interfaces/idp/organization/member/index.ts
@@ -1,4 +1,4 @@
-import { OrganizationRole } from ".."
+import { OrganizationRole } from "..";
 
 export interface OrganizationMember {
     _id: string;

--- a/src/lib/service/high5/wave/s3/index.ts
+++ b/src/lib/service/high5/wave/s3/index.ts
@@ -8,6 +8,7 @@ import {
     EngineRegistry,
     StreamNodeSpecifications,
     StreamNodeSpecificationWrappedWithEngineVersion,
+    WildcardRegistry,
 } from "../../../../interfaces/high5";
 
 /**
@@ -60,6 +61,23 @@ export class S3 extends Base {
         const resp = await this.axios.get<Engine>(`${engineUrl}`, { headers: disableCacheHeaders });
 
         return resp.data;
+    }
+
+    /**
+     * Get a list of available wildcards of a specific engine version from the S3 bucket
+     * @param engineUrl Public url of the engine
+     * @param engineVersion Version of the enigne
+     * @returns Wildcards.json list of available wildcards
+     */
+    async getWildcardsOfEngine(engineUrl: string, engineVersion: string): Promise<WildcardRegistry | undefined> {
+        try {
+            const resp = await this.axios.get<WildcardRegistry>(`${engineUrl.replace("/index.json", "")}/${engineVersion}/Wildcards.json`, {
+                headers: disableCacheHeaders,
+            });
+            return resp.data;
+        } catch (error) {
+            return undefined;
+        }
     }
 
     /**


### PR DESCRIPTION
feat: add endpoint to retrieve the wildcards.json from s3