### PR TITLE
HCLOUD-3378_Fix-fetch-catalog-registry-in-the-SDK_Jorge-Brown

### DIFF
--- a/src/lib/service/high5/wave/s3/index.ts
+++ b/src/lib/service/high5/wave/s3/index.ts
@@ -1,4 +1,5 @@
-import { AxiosInstance } from "axios";
+import axios, { AxiosInstance } from "axios";
+import { version } from "../../../../../package.json";
 import Base, { Options } from "../../../../Base";
 import { disableCacheHeaders } from "../../../../interfaces/axios";
 import {
@@ -11,6 +12,7 @@ import {
     WildcardRegistry,
 } from "../../../../interfaces/high5";
 
+const sdkVersion = "hcloud-sdk-js/v" + version;
 /**
  * Class for reading the S3 bucket of a wave engine and catalogs
  */
@@ -25,7 +27,9 @@ export class S3 extends Base {
      * @returns registry.json
      */
     async getCatalogRegistry(waveBucketUrl: string): Promise<CatalogRegistry> {
-        const resp = await this.axios.get<CatalogRegistry>(`${waveBucketUrl}/catalogs/registry.json`, { headers: disableCacheHeaders });
+        const resp = await axios.get<CatalogRegistry>(`${waveBucketUrl}/catalogs/registry.json`, {
+            headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion },
+        });
 
         return resp.data;
     }
@@ -36,7 +40,9 @@ export class S3 extends Base {
      * @returns registry.json
      */
     async getEngineRegistry(waveBucketUrl: string): Promise<EngineRegistry> {
-        const resp = await this.axios.get<EngineRegistry>(`${waveBucketUrl}/engines/registry.json`, { headers: disableCacheHeaders });
+        const resp = await axios.get<EngineRegistry>(`${waveBucketUrl}/engines/registry.json`, {
+            headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion },
+        });
 
         return resp.data;
     }
@@ -47,7 +53,7 @@ export class S3 extends Base {
      * @returns index.json of catalog
      */
     async getCatalog(catalogUrl: string): Promise<Catalog> {
-        const resp = await this.axios.get<Catalog>(`${catalogUrl}`, { headers: disableCacheHeaders });
+        const resp = await axios.get<Catalog>(`${catalogUrl}`, { headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion } });
 
         return resp.data;
     }
@@ -58,7 +64,7 @@ export class S3 extends Base {
      * @returns index.json of catalog
      */
     async getEngine(engineUrl: string): Promise<Engine> {
-        const resp = await this.axios.get<Engine>(`${engineUrl}`, { headers: disableCacheHeaders });
+        const resp = await axios.get<Engine>(`${engineUrl}`, { headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion } });
 
         return resp.data;
     }
@@ -70,8 +76,8 @@ export class S3 extends Base {
      * @returns Wildcards.json list of available wildcards
      */
     async getWildcardsOfEngine(engineUrl: string, engineVersion: string): Promise<WildcardRegistry> {
-        const resp = await this.axios.get<WildcardRegistry>(`${engineUrl.replace("/index.json", "")}/${engineVersion}/wildcards.json`, {
-            headers: disableCacheHeaders,
+        const resp = await axios.get<WildcardRegistry>(`${engineUrl.replace("/index.json", "")}/${engineVersion}/wildcards.json`, {
+            headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion },
         });
         return resp.data;
     }
@@ -87,8 +93,8 @@ export class S3 extends Base {
         version: string
     ): Promise<StreamNodeSpecifications[] | StreamNodeSpecificationWrappedWithEngineVersion> {
         const specificationUrl = catalogUrl.split("/").slice(0, -1).join("/") + "/" + version + "/specification.json";
-        const resp = await this.axios.get<StreamNodeSpecifications[] | StreamNodeSpecificationWrappedWithEngineVersion>(specificationUrl, {
-            headers: disableCacheHeaders,
+        const resp = await axios.get<StreamNodeSpecifications[] | StreamNodeSpecificationWrappedWithEngineVersion>(specificationUrl, {
+            headers: { ...disableCacheHeaders, "x-hcloud-user-agent": sdkVersion },
         });
 
         return resp.data;
@@ -102,7 +108,7 @@ export class S3 extends Base {
      */
     async getNodeDocumentation(catalogUrl: string, version: string, nodeName: string): Promise<string> {
         const specificationUrl = catalogUrl.split("/").slice(0, -1).join("/") + `/${version}/docs/${nodeName}.md`;
-        const resp = await this.axios.get<string>(specificationUrl).catch(err => {
+        const resp = await axios.get<string>(specificationUrl).catch(err => {
             throw new Error(`Node documentation not found: ${err}`);
         });
 


### PR DESCRIPTION
Some S3 providers will attempt to validate authorization headers if they are sent even against a public endpoint. To avoid this we stop using the AxiosInstance where the default headers are set.