### PR TITLE
HCLOUD-3743_Double-asset-display-after-uploading-a-new-asset_Artur-Grafov

### DIFF
--- a/src/lib/service/cosmo/index.ts
+++ b/src/lib/service/cosmo/index.ts
@@ -3,6 +3,7 @@ import { Version } from "../../interfaces/global";
 import { CosmoAsset } from "./asset";
 import { CosmoComment } from "./comment";
 import { CosmoFolder } from "./folder";
+import { CosmoSpaceInternal } from "./internal/space";
 import { CosmoLocation } from "./location";
 import { CosmoNamespace } from "./namespace";
 import { CosmoOrganization } from "./organization";
@@ -82,6 +83,14 @@ export default class CosmoService extends Base {
         return this._cosmoOrganization;
     }
     private _cosmoOrganization?: CosmoOrganization;
+
+    public get cosmoSpaceInternal(): CosmoSpaceInternal {
+        if (this._cosmoSpaceInternal === undefined) {
+            this._cosmoSpaceInternal = new CosmoSpaceInternal(this.options, this.axios);
+        }
+        return this._cosmoSpaceInternal;
+    }
+    private _cosmoSpaceInternal?: CosmoSpaceInternal;
 
     /**
      * Requests the endpoint version

--- a/src/lib/service/cosmo/internal/index.ts
+++ b/src/lib/service/cosmo/internal/index.ts
@@ -1,0 +1,16 @@
+import Base from "../../../Base";
+import { CosmoSpaceInternal } from "./space";
+
+export class CosmoInternal extends Base {
+    public get space(): CosmoSpaceInternal {
+        if (this._space === undefined) {
+            this._space = new CosmoSpaceInternal(this.options, this.axios);
+        }
+        return this._space;
+    }
+    private _space?: CosmoSpaceInternal;
+
+    protected getEndpoint(endpoint: string): string {
+        return `${this.options.server}/api/cosmo/internal${endpoint}`;
+    }
+}

--- a/src/lib/service/cosmo/internal/space/index.ts
+++ b/src/lib/service/cosmo/internal/space/index.ts
@@ -1,0 +1,22 @@
+import { AxiosInstance } from "axios";
+import Base, { Options } from "../../../../Base";
+
+export class CosmoSpaceInternal extends Base {
+    constructor(options: Options, axios: AxiosInstance) {
+        super(options, axios);
+    }
+
+    /**
+     * Deletes all spaces of an organization and the organization itself.
+     *
+     * THIS IS AN INTERNAL ENDPOINT AND CAN ONLY BE USED FROM BACKENDS WITHIN THE HCLOUD DEPLOYMENT
+     * @param orgId ID of the organization
+     */
+    async deleteSpacesOfDeletedOrg(orgId: string): Promise<void> {
+        await this.axios.delete(this.getEndpoint(`/v1/org/${orgId}/spaces`));
+    }
+
+    protected getEndpoint(endpoint: string): string {
+        return `${this.options.server}/api/cosmo/internal${endpoint}`;
+    }
+}


### PR DESCRIPTION
feat: add internal cosmo endpoint for space/org housekeep