### PR TITLE
HCLOUD-3842 Add account name to v1org{orgName}connectsearch response

### DIFF
--- a/src/lib/interfaces/mothership/index.ts
+++ b/src/lib/interfaces/mothership/index.ts
@@ -1,3 +1,5 @@
+import { ReducedUser } from "../idp";
+
 export enum AgentStatus {
     BUSY = "BUSY",
     IDLE = "IDLE",
@@ -26,5 +28,5 @@ export type Agent = {
 
 export type TargetAgent = Pick<Agent, Exclude<keyof Agent, "uptime">> & {
     connectionUptime: number;
-    targetEmail: string;
+    target: ReducedUser;
 };


### PR DESCRIPTION
Linked task: [HCLOUD-3842 Add account name to v1org{orgName}connectsearch response in Mothership](https://app.clickup.com/t/2570196/HCLOUD-3842).