### PR TITLE
HCLOUD-3860_Creation-of-a-folder-within-a-folder-creats-it-on-root-level_Jorge-Brown

### DIFF
--- a/src/lib/service/cosmo/folder/index.ts
+++ b/src/lib/service/cosmo/folder/index.ts
@@ -28,7 +28,7 @@ export class CosmoFolder extends Base {
     async createFolder(orgName: string, spaceName: string, folderName: string, parentId?: string): Promise<Folder> {
         const resp = await this.axios.post<Folder>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/folders`), {
             name: folderName,
-            parent: parentId,
+            parentId: parentId,
         });
 
         return resp.data;


### PR DESCRIPTION
Fixes an issue where the folder would always be created on the root level because the parentId parameter was being sent incorrectly.