### PR TITLE
HCLOUD-4076 Use target event name instead of _id for High5 Job

### DIFF
--- a/src/lib/interfaces/high5/space/job/index.ts
+++ b/src/lib/interfaces/high5/space/job/index.ts
@@ -87,5 +87,5 @@ export interface Job {
 }
 
 export type JobCreate = Pick<Job, "name" | "expression" | "payload" | "enabled" | "description" | "lastStatus" | "lastTriggered" | "time"> & {
-    targetEventId: string;
+    targetEvent: string;
 };


### PR DESCRIPTION
Linked task: [HCLOUD-4076 High5 cronjob changes](https://app.clickup.com/t/2570196/HCLOUD-4076).