### PR TITLE
HCLOUD-4277_High5-Expose-source-stream-context-in-sub-stream-execution_Jorge-Brown

### DIFF
--- a/src/lib/interfaces/high5/space/event/stream/node/index.ts
+++ b/src/lib/interfaces/high5/space/event/stream/node/index.ts
@@ -58,6 +58,7 @@ export interface StreamSingleNodeResult {
     uuid: string;
     nodeUuid: string;
     failed: boolean;
+    streamId?: string;
     startTimestamp: number;
     endTimestamp?: number;
     name: string;

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -194,6 +194,7 @@ export interface StreamNode {
     breakpoint?: boolean;
     color?: string;
     nodeType?: NodeType;
+    streamId?: string;
 }
 
 export interface High5ExecuteOnAgentRequest {


### PR DESCRIPTION
Allows the distiction between embedded and non-embedded nodes.