### PR TITLE
feat: add optional auto refresh logic to SDK if a refreshToken is set

### DIFF
--- a/src/lib/Hcloud.ts
+++ b/src/lib/Hcloud.ts
@@ -2,7 +2,8 @@ import axios, { AxiosInstance } from "axios";
 import { version } from "../package.json";
 import { HcloudLogger, Options } from "./Base";
 import wrapError from "./helper/ErrorHelper";
-import { disableCacheHeaders } from "./interfaces/axios";
+import { disableCacheHeaders, RefreshToken } from "./interfaces/axios";
+import { GrantType, OAuthToken, OAuthTokenRequest } from "./interfaces/idp";
 import AgentService from "./service/agent";
 import AuditorService from "./service/auditor";
 import BouncerService from "./service/bouncer";
@@ -107,6 +108,9 @@ export class HCloud {
     private options: Options;
     private axios: AxiosInstance;
 
+    private refreshToken: RefreshToken | null = null;
+    private refreshPromise: Promise<OAuthToken> | null = null;
+
     constructor(options: Options) {
         this.options = options;
         this.axios = axios.create({
@@ -130,6 +134,44 @@ export class HCloud {
                 this.options.logger?.error(String(error), error);
 
                 return Promise.reject(wrapError(error));
+            }
+        );
+
+        // add request interceptor to handle auto token refresh if set
+        this.axios.interceptors.request.use(async config => {
+            if (!this.refreshToken) return config;
+
+            const isExpired = Date.now() >= this.refreshToken.expiresAt - 120 * 1000; // consider token expired if it will expire in the next 120 seconds
+
+            if (isExpired) {
+                await this.refreshAccessToken();
+            } else if (this.refreshPromise) {
+                await this.refreshPromise;
+            }
+
+            return config;
+        });
+
+        // trigger refresh logic in case of 401 has been received and a refresh token is set
+        this.axios.interceptors.response.use(
+            res => res,
+            async error => {
+                const originalRequest = error.config;
+
+                if (this.refreshToken) {
+                    if (error.response?.status === 401 && !originalRequest._retry) {
+                        originalRequest._retry = true;
+
+                        const newToken = await this.refreshAccessToken();
+                        if (newToken) {
+                            originalRequest.headers.Authorization = `Bearer ${newToken.access_token}`;
+                        }
+
+                        return this.axios(originalRequest);
+                    }
+                }
+
+                return Promise.reject(error);
             }
         );
     }
@@ -170,6 +212,21 @@ export class HCloud {
      */
     getAuthToken(): string | undefined {
         return this.axios.defaults.headers.common["authorization"]?.toString();
+    }
+
+    /**
+     * Sets the refresh token and enables auto-fresh
+     */
+    setRefreshToken(refreshToken: RefreshToken): HCloud {
+        this.refreshToken = refreshToken;
+        return this;
+    }
+
+    /**
+     * Returns the currently set refresh token.
+     */
+    getRefreshToken(): RefreshToken | null {
+        return this.refreshToken;
     }
 
     /**
@@ -230,5 +287,47 @@ export class HCloud {
      */
     setAxios(axios: AxiosInstance): AxiosInstance {
         return (this.axios = axios);
+    }
+
+    /**
+     * refreshAccessToken will refresh the access_token using a given refresh_token and set the new access_token and refresh_token in the SDK.
+     * If multiple requests trigger a token refresh at the same time, only one request will actually call the token endpoint, while the others will wait for the result of that request and use the same new token.
+     *
+     * This method will trigger a callback? to enable the returned values to be persisted
+     */
+    private async refreshAccessToken(): Promise<OAuthToken | null> {
+        if (!this.refreshToken) throw new Error("no refresh token set");
+
+        if (!this.refreshPromise) {
+            this.refreshPromise = this.Idp.oAuth
+                .exchangeCodeForToken({
+                    // eslint-disable-next-line camelcase
+                    grant_type: GrantType.REFRESH_TOKEN,
+                    // eslint-disable-next-line camelcase
+                    refresh_token: this.refreshToken.token,
+                } as OAuthTokenRequest)
+                .then(res => {
+                    this.refreshPromise = null;
+
+                    if (res.access_token) {
+                        this.setAuthToken(`Bearer ${res.access_token}`);
+                        const newRefreshToken = {
+                            token: res.refresh_token!,
+                            expiresAt: Date.now() + (res.expires_in ?? 0) * 1000,
+                            callback: this.refreshToken?.callback,
+                        } as RefreshToken;
+                        this.setRefreshToken(newRefreshToken);
+                        this.refreshToken?.callback?.(res.access_token, newRefreshToken); // call callback to hydrate localStorage with the new refresh token for example
+                    }
+                    return res;
+                })
+                .catch(err => {
+                    this.refreshPromise = null;
+                    this.refreshToken = null;
+                    throw err;
+                });
+        }
+
+        return this.refreshPromise;
     }
 }

--- a/src/lib/interfaces/axios/index.ts
+++ b/src/lib/interfaces/axios/index.ts
@@ -3,3 +3,9 @@ export const disableCacheHeaders = {
     Pragma: "no-cache",
     Expires: "0",
 };
+
+export type RefreshToken = {
+    token: string;
+    expiresAt: number;
+    callback?: (newAccessToken: string, newRefreshToken: RefreshToken) => void;
+};

--- a/src/lib/interfaces/cosmo/asset/index.ts
+++ b/src/lib/interfaces/cosmo/asset/index.ts
@@ -1,10 +1,10 @@
-import { ReducedSpace } from "../../global"
-import { SearchFilterComparatorString, SearchFilterType } from "../../global/SearchFilters"
-import { ReducedTeam } from "../../idp"
-import { ReducedOrganization } from "../../idp/organization"
-import { ReducedUser } from "../../idp/user"
-import { CosmoSpace } from "../space"
-import { Tag } from "../tag/tag"
+import { ReducedSpace } from "../../global";
+import { SearchFilterComparatorString, SearchFilterType } from "../../global/SearchFilters";
+import { ReducedTeam } from "../../idp";
+import { ReducedOrganization } from "../../idp/organization";
+import { ReducedUser } from "../../idp/user";
+import { CosmoSpace } from "../space";
+import { Tag } from "../tag/tag";
 
 export interface BaseAsset {
     _id: string;

--- a/src/lib/service/cosmo/namespace/index.ts
+++ b/src/lib/service/cosmo/namespace/index.ts
@@ -1,6 +1,6 @@
-import Base, { MaybeRaw } from "../../../Base"
-import { Asset, NamespaceMetadata, NamespaceRushStatus } from "../../../interfaces/cosmo/asset"
-import { Namespace } from "../../../interfaces/cosmo/namespace"
+import Base, { MaybeRaw } from "../../../Base";
+import { Asset, NamespaceMetadata, NamespaceRushStatus } from "../../../interfaces/cosmo/asset";
+import { Namespace } from "../../../interfaces/cosmo/namespace";
 
 /**
  * @class Namespace


### PR DESCRIPTION
add optional auto refresh logic with:
* blocking to avoid multiple refresh requests
* optional callback to enable persisting of tokens
* add auto refresh
* add refresh on error if RefreshToken is set