### PR TITLE
Create new public release

### DIFF
--- a/src/lib/interfaces/agent/index.ts
+++ b/src/lib/interfaces/agent/index.ts
@@ -10,6 +10,7 @@ export interface InstallerVersion {
     published_date: number; // unix timestamp
     version: string;
     os: "darwin" | "windows";
+    arch?: "x64" | "arm64";
     dev: boolean;
 }
 

--- a/src/lib/interfaces/cosmo/asset/index.ts
+++ b/src/lib/interfaces/cosmo/asset/index.ts
@@ -39,6 +39,8 @@ export type Asset = BaseAsset &
                   string,
                   { status: string; statusAuthor?: ReducedUser; canWriteStatus?: boolean; tag?: Tag; metadata?: NamespaceMetadata }
               >;
+              queuePosition?: number;
+              queueTotal?: number;
           }
         | Production
         | Folder

--- a/src/lib/interfaces/cosmo/asset/index.ts
+++ b/src/lib/interfaces/cosmo/asset/index.ts
@@ -35,7 +35,10 @@ export type Asset = BaseAsset &
               frameRate?: number;
               media?: Media[];
               thumbnailUrl?: string;
-              namespaces?: Record<string, { status: string; tag?: Tag; metadata?: NamespaceMetadata }>;
+              namespaces?: Record<
+                  string,
+                  { status: string; statusAuthor?: ReducedUser; canWriteStatus?: boolean; tag?: Tag; metadata?: NamespaceMetadata }
+              >;
           }
         | Production
         | Folder

--- a/src/lib/interfaces/cosmo/asset/index.ts
+++ b/src/lib/interfaces/cosmo/asset/index.ts
@@ -35,6 +35,7 @@ export type Asset = BaseAsset &
               frameRate?: number;
               media?: Media[];
               thumbnailUrl?: string;
+              posterUrl?: string;
               namespaces?: Record<
                   string,
                   { status: string; statusAuthor?: ReducedUser; canWriteStatus?: boolean; tag?: Tag; metadata?: NamespaceMetadata }

--- a/src/lib/interfaces/cosmo/comment/index.ts
+++ b/src/lib/interfaces/cosmo/comment/index.ts
@@ -22,6 +22,18 @@ export enum CommentType {
     REPLY = "REPLY",
 }
 
+export enum CommentSortField {
+    TIMECODE = "TIMECODE",
+    CREATOR = "CREATOR",
+    NEWEST = "NEWEST",
+    OLDEST = "OLDEST",
+}
+
+export enum CommentSortDirection {
+    ASC = "ASC",
+    DESC = "DESC",
+}
+
 export interface Comment {
     _id: string;
     text: string;

--- a/src/lib/interfaces/cosmo/comment/index.ts
+++ b/src/lib/interfaces/cosmo/comment/index.ts
@@ -15,6 +15,7 @@ export interface EditComment {
     annotation?: string;
     mentions?: string[];
     mentionsTeams?: string[];
+    completed?: boolean;
 }
 
 export enum CommentType {
@@ -46,6 +47,9 @@ export interface Comment {
     mentions?: ReducedUser[];
     mentionedTeams?: ReducedTeam[];
     replies?: Reply[];
+    completed: boolean;
+    completedBy?: ReducedUser;
+    completedAt?: number;
 }
 
 export interface Reply extends Omit<Comment, "timestamp" | "replies"> {

--- a/src/lib/interfaces/cosmo/share/index.ts
+++ b/src/lib/interfaces/cosmo/share/index.ts
@@ -1,4 +1,5 @@
 import { ReducedUser, ShareReducedUnlinkedUser, User } from "../../idp";
+import { ItemType } from "../asset";
 
 /**
  * Represents a public link for sharing.
@@ -29,7 +30,7 @@ export interface Share {
     name: string;
     creator: ReducedUser;
     createDate: number;
-    items: string[];
+    items?: ({ _id: string; name: string; type: ItemType.FOLDER } | { _id: string; name: string; type: ItemType.MEDIA_ASSET; thumbnail: string })[];
     permissions?: string[];
     permissionGroups?: ShareAssetPermissionGroup[];
     namespaces?: Record<string, string[]>;
@@ -39,7 +40,6 @@ export interface Share {
     publicLink?: PublicLink;
     users?: (User | ReducedUser | ShareReducedUnlinkedUser)[];
     waiting: boolean;
-    thumbnails?: string[];
 }
 
 /**

--- a/src/lib/interfaces/cosmo/share/index.ts
+++ b/src/lib/interfaces/cosmo/share/index.ts
@@ -39,6 +39,7 @@ export interface Share {
     publicLink?: PublicLink;
     users?: (User | ReducedUser | ShareReducedUnlinkedUser)[];
     waiting: boolean;
+    thumbnails?: string[];
 }
 
 /**

--- a/src/lib/interfaces/cosmo/share/index.ts
+++ b/src/lib/interfaces/cosmo/share/index.ts
@@ -30,7 +30,10 @@ export interface Share {
     name: string;
     creator: ReducedUser;
     createDate: number;
-    items?: ({ _id: string; name: string; type: ItemType.FOLDER } | { _id: string; name: string; type: ItemType.MEDIA_ASSET; thumbnail: string })[];
+    items?: (
+        | { _id: string; name: string; type: ItemType.FOLDER }
+        | { _id: string; name: string; type: ItemType.MEDIA_ASSET; thumbnailUrl: string }
+    )[];
     permissions?: string[];
     permissionGroups?: ShareAssetPermissionGroup[];
     namespaces?: Record<string, string[]>;

--- a/src/lib/interfaces/cosmo/tag/tag.ts
+++ b/src/lib/interfaces/cosmo/tag/tag.ts
@@ -2,6 +2,7 @@ export interface Tag {
     _id: string;
     name: string;
     color: string;
+    position: number;
 }
 
 export interface CreateTag {

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -58,7 +58,7 @@ export interface EventExecutionResult {
 }
 
 export interface High5ExecutionPackage {
-    design: DesignBuild;
+    design?: DesignBuild;
     payload: High5ExecutionPayload;
     waveCatalogs: WaveCatalog[];
     waveEngine: WaveEngine;

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -94,7 +94,9 @@ enum TriggerSource {
 export interface ExtendedHigh5ExecutionPackage extends High5ExecutionPackage {
     hcl: HCloud;
     orgName: string;
+    orgId: string;
     spaceName: string;
+    spaceId: string;
     streamId: string;
     secret: string;
     targetEmail: string;
@@ -200,6 +202,7 @@ export interface StreamNode {
 export interface High5ExecuteOnAgentRequest {
     organizationName: string;
     spaceName: string;
+    spaceId: string;
     streamId: string;
     secret: string;
     subject: string;

--- a/src/lib/interfaces/high5/space/job/JobLog.ts
+++ b/src/lib/interfaces/high5/space/job/JobLog.ts
@@ -2,17 +2,22 @@ import { Header, ReducedSpace } from "../../../global";
 import { ReducedOrganization } from "../../../idp/organization";
 import { ReducedUser } from "../../../idp/user";
 
-export interface JobLogDto {
+export interface ReducedJob {
     _id: string;
-    jobId: string;
-    statusCode: number;
-    organization: ReducedOrganization;
-    creator: ReducedUser;
-    space: ReducedSpace;
-    headers?: Header[];
-    body?: string;
-    createDate: number;
-    modifyDate: number;
+    name: string;
 }
 
-export type JobLogCreate = Pick<JobLogDto, "statusCode" | "headers" | "body">;
+export interface JobLogDto {
+    _id: string;
+    job: ReducedJob;
+    space: ReducedSpace;
+    organization: ReducedOrganization;
+    creator: ReducedUser;
+    statusCode: number;
+    headers?: Header[];
+    payload?: string;
+    errorMessage?: string;
+    createDate: number;
+}
+
+export type JobLogCreate = Pick<JobLogDto, "statusCode" | "headers" | "payload" | "errorMessage">;

--- a/src/lib/interfaces/high5/space/job/index.ts
+++ b/src/lib/interfaces/high5/space/job/index.ts
@@ -70,10 +70,10 @@ export interface Job {
     _id: string;
     name: string;
     expression: string;
+    targetEvent: ReducedEvent;
+    space: ReducedSpace;
     organization: ReducedOrganization;
     creator: ReducedUser;
-    space: ReducedSpace;
-    targetEvent: ReducedEvent;
     timezone: string;
     description?: string;
     payload?: string;

--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -1,3 +1,5 @@
+import { FieldCondition, InputObject, Primitive, Query } from "./dependentInputs";
+
 export interface RegistryCatalog {
     name: string;
     description: string;
@@ -102,7 +104,7 @@ export interface StreamNodeSpecificationV1 extends StreamNodeSpecification {
     version: StreamSemanticVersion;
     author: StreamNodeSpecificationAuthor;
     tag?: StreamNodeSpecificationTag;
-    inputs?: StreamNodeSpecificationInput[];
+    inputs?: StreamNodeSpecificationInput[] | StreamNodeSpecificationConditionalInput[];
     outputs?: StreamNodeSpecificationOutput[];
     additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
     path?: string;
@@ -116,7 +118,7 @@ export interface StreamNodeSpecificationV2 extends StreamNodeSpecification {
     version: StreamSemanticVersion;
     author: StreamNodeSpecificationAuthor;
     tag?: StreamNodeSpecificationTag[];
-    inputs?: StreamNodeSpecificationInput[];
+    inputs?: StreamNodeSpecificationInput[] | StreamNodeSpecificationConditionalInput[];
     outputs?: StreamNodeSpecificationOutputV2[];
     additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
     path?: string;
@@ -193,6 +195,10 @@ export type StreamNodeSpecificationInput = {
           defaultValue: boolean;
       }
 );
+
+export type StreamNodeSpecificationDependentInput = StreamNodeSpecificationInput & {
+    if?: Primitive | InputObject | FieldCondition | Query;
+};
 
 export interface StreamNodeSpecificationOutput {
     name: string;

--- a/src/lib/interfaces/high5/wave/index.ts
+++ b/src/lib/interfaces/high5/wave/index.ts
@@ -1,4 +1,4 @@
-import { FieldCondition, InputObject, Primitive, Query } from "./dependentInputs";
+import { InputObject, Query } from "./dependentInputs";
 
 export interface RegistryCatalog {
     name: string;
@@ -104,7 +104,7 @@ export interface StreamNodeSpecificationV1 extends StreamNodeSpecification {
     version: StreamSemanticVersion;
     author: StreamNodeSpecificationAuthor;
     tag?: StreamNodeSpecificationTag;
-    inputs?: StreamNodeSpecificationInput[] | StreamNodeSpecificationConditionalInput[];
+    inputs?: StreamNodeSpecificationInput[];
     outputs?: StreamNodeSpecificationOutput[];
     additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
     path?: string;
@@ -118,7 +118,7 @@ export interface StreamNodeSpecificationV2 extends StreamNodeSpecification {
     version: StreamSemanticVersion;
     author: StreamNodeSpecificationAuthor;
     tag?: StreamNodeSpecificationTag[];
-    inputs?: StreamNodeSpecificationInput[] | StreamNodeSpecificationConditionalInput[];
+    inputs?: StreamNodeSpecificationInput[];
     outputs?: StreamNodeSpecificationOutputV2[];
     additionalConnectors?: StreamNodeSpecificationAdditionalConnector[];
     path?: string;
@@ -128,6 +128,10 @@ export interface StreamNodeSpecificationV2 extends StreamNodeSpecification {
 export type StreamNodeSpecificationV3 = Omit<StreamNodeSpecificationV2, "specVersion"> & {
     specVersion: 3;
     deprecated: boolean;
+};
+export type StreamNodeSpecificationV4<T extends InputObject = InputObject> = Omit<StreamNodeSpecificationV3, "specVersion" | "inputs"> & {
+    specVersion: 4;
+    inputs?: StreamNodeSpecificationDependendInput<T>[];
 };
 /**
  * This functions will return true when the specVersion is undefined to account for older catalogs/nodes
@@ -142,6 +146,9 @@ export function isStreamNodeSpecificationV2(s: StreamNodeSpecification): s is St
 }
 export function isStreamNodeSpecificationV3(s: StreamNodeSpecification): s is StreamNodeSpecificationV3 {
     return s.specVersion === 3;
+}
+export function isStreamNodeSpecificationV4<T extends InputObject = InputObject>(s: StreamNodeSpecification): s is StreamNodeSpecificationV4<T> {
+    return s.specVersion === 4;
 }
 
 export interface StreamCustomNodeSpecification {
@@ -196,8 +203,8 @@ export type StreamNodeSpecificationInput = {
       }
 );
 
-export type StreamNodeSpecificationDependentInput = StreamNodeSpecificationInput & {
-    if?: Primitive | InputObject | FieldCondition | Query;
+export type StreamNodeSpecificationDependendInput<T extends InputObject = InputObject> = StreamNodeSpecificationInput & {
+    if?: Query<T>;
 };
 
 export interface StreamNodeSpecificationOutput {

--- a/src/lib/service/cosmo/comment/index.ts
+++ b/src/lib/service/cosmo/comment/index.ts
@@ -1,5 +1,5 @@
 import Base, { MaybeRaw } from "../../../Base";
-import { Comment, CreateComment, EditComment, Reply } from "../../../interfaces/cosmo/comment";
+import { Comment, CommentSortDirection, CommentSortField, CreateComment, EditComment, Reply } from "../../../interfaces/cosmo/comment";
 
 /**
  * @class Comment
@@ -53,6 +53,8 @@ export class CosmoComment extends Base {
      * @param page Page number for pagination
      * @param annotation Whether to include annotations in the response
      * @param replySample Amount of replies to load
+     * @param sortField Field to sort comments by
+     * @param sortDirection Sort direction for comments
      * @param accept The Accept header value, either "application/json" (comments response as json)
      *                  or "application/mediacomposer+xml" (comments response as media composer xml as download)
      *                  or "application/fcp+xml" (comments response as fcp xml as download => i.e. for Adobe Premiere Pro)
@@ -68,6 +70,8 @@ export class CosmoComment extends Base {
         page?: number,
         annotation: boolean = false,
         replySample: number = 0,
+        sortField?: CommentSortField,
+        sortDirection?: CommentSortDirection,
         accept?: A,
         raw?: { raw: R }
     ): Promise<A extends "application/mediacomposer+xml" | "application/fcp+xml" | "text/edl" ? ArrayBuffer : MaybeRaw<R, Comment[]>> {
@@ -79,7 +83,7 @@ export class CosmoComment extends Base {
 
         const resp = await this.axios.get(
             this.getEndpoint(
-                `/v1/org/${orgName}/spaces/${spaceName}/namespaces/${namespaceName}/comments?limit=${limit}&page=${page}&annotation=${annotation}&refId=${refId}&replySample=${replySample}`
+                `/v1/org/${orgName}/spaces/${spaceName}/namespaces/${namespaceName}/comments?limit=${limit}&page=${page}&annotation=${annotation}&refId=${refId}&replySample=${replySample}${sortField !== undefined ? `&sort_field=${sortField}` : ""}${sortDirection !== undefined ? `&sort_direction=${sortDirection}` : ""}`
             ),
             {
                 headers: {

--- a/src/lib/service/cosmo/share/index.ts
+++ b/src/lib/service/cosmo/share/index.ts
@@ -260,4 +260,35 @@ export class CosmoShare extends Base {
 
         return (raw?.raw ? resp : undefined) as MaybeRaw<R, undefined>;
     }
+
+    /**
+     * Sends a share email to a **specific recipient** after he clicks a public link.
+     *
+     *
+     * @typeParam R - When `true`, the raw Axios response is returned instead of `undefined`
+     *
+     * @param orgName   - The organization identifier
+     * @param spaceName - The space identifier within the organization
+     * @param shareId   - The share ID whose emails should be resent
+     * @param email     - The email address of the recipient
+     * @param shareIdHMAC - The HMAC of the share ID
+     * @param raw       - Optional flag to return the raw Axios response
+     *
+     * @returns `undefined` by default, or the raw Axios response when `raw.raw` is `true`
+     */
+    async sendShareEmailAfterPublicLinkClick<R extends boolean = false>(
+        orgName: string,
+        spaceName: string,
+        shareId: string,
+        email: string,
+        shareIdHMAC: string,
+        raw?: { raw: R }
+    ): Promise<MaybeRaw<R, undefined>> {
+        const resp = await this.axios.post(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/shares/${shareId}/email/publicLink`), {
+            email,
+            shareIdHMAC,
+        });
+
+        return (raw?.raw ? resp : undefined) as MaybeRaw<R, undefined>;
+    }
 }

--- a/src/lib/service/cosmo/tag/index.ts
+++ b/src/lib/service/cosmo/tag/index.ts
@@ -89,6 +89,29 @@ export class CosmoTag extends Base {
     }
 
     /**
+     * Reorder Tags in Cosmo inside the specified Organization, Space and Namespace.
+     * @remarks
+     * ** Under development, breaking changes possible**
+     * @param orgName Name of the Organization
+     * @param spaceName Name of the Space
+     * @param namespaceName Name of the Namespace
+     * @param tagIds Ordered array of tag IDs representing the desired sort order
+     * @returns 204 No Content if successful
+     */
+    async reorderTags<R extends boolean = false>(
+        orgName: string,
+        spaceName: string,
+        namespaceName: string,
+        tagIds: string[],
+        raw?: { raw: R }
+    ): Promise<MaybeRaw<R, void>> {
+        const resp = await this.axios.put(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/namespaces/${namespaceName}/tags/reorder`), {
+            tagIds,
+        });
+        return (raw?.raw ? resp : undefined) as MaybeRaw<R, void>;
+    }
+
+    /**
      * Delete a Tag in Cosmo inside the specified Organization, Space and Namespace.
      * @remarks
      * ** Under development, breaking changes possible**

--- a/src/lib/service/high5/space/execution/index.ts
+++ b/src/lib/service/high5/space/execution/index.ts
@@ -92,6 +92,7 @@ export class High5SpaceExecute extends Base {
      * @param spaceName Name of the Space
      * @param streamId ID of the Stream
      * @param secret Secret of the Stream execution object
+     * @param hash (Optional) SHA-256 hash of the cached design to prevent redundant downloads
      * @returns StreamExecutionPackage
      */
     async getStreamExecutionPackage<R extends boolean = false>(
@@ -99,10 +100,12 @@ export class High5SpaceExecute extends Base {
         spaceName: string,
         streamId: string,
         secret: string,
+        hash?: string,
         raw?: { raw: R }
     ): Promise<MaybeRaw<R, High5ExecutionPackage>> {
         const resp = await this.axios.get<High5ExecutionPackage>(
-            this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execute/stream/id/${streamId}/package/${secret}`)
+            this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/execute/stream/id/${streamId}/package/${secret}`),
+            { params: { hash } }
         );
 
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, High5ExecutionPackage>;


### PR DESCRIPTION
I need to create a new public release in npmjs in order to update the  `hcloud-catalog-upload-action` repository with the newly introduced `StreamNodeSpecificationDependendInput` so `wave-node` pipeline succeeds to create a new default catalog, holding this feature.