### PR TITLE
HCLOUD-4607 Add TTL support for documents

### DIFF
--- a/src/lib/interfaces/high5/space/database/document/index.ts
+++ b/src/lib/interfaces/high5/space/database/document/index.ts
@@ -23,6 +23,7 @@ interface Document {
     creator: ReducedUser;
     type: DocumentType;
     value: any;
+    ttl?: number;
     createDate: number;
     modifyDate: number;
 }
@@ -31,10 +32,12 @@ interface DocumentCreateDto {
     key: string;
     type: DocumentType;
     value: any;
+    ttl?: number;
 }
 
 interface DocumentPatchDto {
     value: any;
+    ttl?: number;
 }
 
 export { Document, DocumentCreateDto, DocumentPatchDto, DocumentType };


### PR DESCRIPTION
Linked task: [HCLOUD-4607 FridayDB - Add TTL support for documents](https://app.clickup.com/t/2570196/HCLOUD-4607).