### PR TITLE
HCLOUD-4606 Implement upsert document endpoint

### DIFF
--- a/src/lib/interfaces/high5/space/database/document/index.ts
+++ b/src/lib/interfaces/high5/space/database/document/index.ts
@@ -39,3 +39,9 @@ export interface DocumentPatchDto {
     value: any;
     ttl?: number;
 }
+
+export interface DocumentUpsertDto extends DocumentPatchDto {
+    key?: string;
+    type?: DocumentType;
+    ttl?: number;
+}

--- a/src/lib/service/high5/space/database/document/index.ts
+++ b/src/lib/service/high5/space/database/document/index.ts
@@ -2,7 +2,7 @@ import Base, { MaybeRaw } from "../../../../../Base";
 import { createPaginatedResponse } from "../../../../../helper/paginatedResponseHelper";
 import { SearchFilterDTO } from "../../../../../helper/searchFilter";
 import { PaginatedResponse, SearchFilter, SearchParams } from "../../../../../interfaces/global";
-import { Document, DocumentCreateDto, DocumentPatchDto } from "../../../../../interfaces/high5";
+import { Document, DocumentCreateDto, DocumentPatchDto, DocumentUpsertDto } from "../../../../../interfaces/high5";
 import { High5DocumentCollection } from "./collection";
 import { High5DocumentNumber } from "./number";
 
@@ -115,6 +115,31 @@ export class High5Document extends Base {
         raw?: { raw: R }
     ): Promise<MaybeRaw<R, Document>> {
         const resp = await this.axios.patch<Document>(
+            this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/databases/${dbName}/documents/${key}`),
+            document
+        );
+
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Document>;
+    }
+
+    /**
+     * Creates the document if it does not exist, or updates it if it does
+     * @param orgName Name of the Organization
+     * @param spaceName Name of the Space
+     * @param dbName Name of the Database
+     * @param key Key of the Document
+     * @param document New value to upsert the Document
+     * @returns Updated or created Document
+     */
+    async upsertDocument<R extends boolean = false>(
+        orgName: string,
+        spaceName: string,
+        dbName: string,
+        key: string,
+        document: DocumentUpsertDto,
+        raw?: { raw: R }
+    ): Promise<MaybeRaw<R, Document>> {
+        const resp = await this.axios.put<Document>(
             this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/databases/${dbName}/documents/${key}`),
             document
         );


### PR DESCRIPTION
Linked task: [HCLOUD-4606 FridayDB - Upsert entities when creating or updating documents](https://app.clickup.com/t/2570196/HCLOUD-4606).