### PR TITLE
HCLOUD-4660_RC-fix-tag-name-whitespace-removal_Artur-Grafov

### DIFF
--- a/src/lib/helper/ValidationHelper.ts
+++ b/src/lib/helper/ValidationHelper.ts
@@ -367,7 +367,7 @@ const entityCollection: Record<Entity, Details> = {
         maxLength: 34,
     },
     [Entity.TAG_NAME]: {
-        pattern: /^[a-zA-Z0-9-]{1,20}$/i,
+        pattern: /^[a-zA-Z0-9- ]{1,20}$/i,
         minLength: 1,
         maxLength: 20,
     },


### PR DESCRIPTION
fix: re-allow whitespace on tag names