### PR TITLE
HCLOUD-4698 Extend cached stream implementation

### DIFF
--- a/src/lib/interfaces/agent/cache/index.ts
+++ b/src/lib/interfaces/agent/cache/index.ts
@@ -1,0 +1,14 @@
+export interface StreamCacheMetadata {
+    streamId: string;
+    orgName: string;
+    spaceName: string;
+    hash: string;
+    hits: number;
+    createdAt: number;
+    remainingTtl: number;
+    lastExecution?: number;
+}
+
+export interface StreamCacheWipeResult {
+    deleted: number;
+}

--- a/src/lib/interfaces/agent/cache/index.ts
+++ b/src/lib/interfaces/agent/cache/index.ts
@@ -2,6 +2,8 @@ export interface StreamCacheMetadata {
     streamId: string;
     orgName: string;
     spaceName: string;
+    eventName: string;
+    streamName: string;
     hash: string;
     hits: number;
     createdAt: number;

--- a/src/lib/interfaces/high5/space/execution/index.ts
+++ b/src/lib/interfaces/high5/space/execution/index.ts
@@ -66,6 +66,8 @@ export interface High5ExecutionPackage {
     info: StreamInfo;
     debug: boolean;
     executionId: string;
+    streamName: string;
+    eventName: string;
 }
 
 type StreamInfo = {

--- a/src/lib/service/agent/cache/index.ts
+++ b/src/lib/service/agent/cache/index.ts
@@ -1,0 +1,49 @@
+import Base, { MaybeRaw } from "../../../Base";
+import { StreamCacheMetadata, StreamCacheWipeResult } from "../../../interfaces/agent/cache";
+
+export class AgentCache extends Base {
+    /**
+     * Retrieves metadata for all currently cached stream definitions.
+     * The cached design content is not exposed.
+     * @returns Array of cached stream metadata
+     */
+    async listStreamCache<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheMetadata[]>> {
+        const resp = await this.axios.get<StreamCacheMetadata[]>(this.getEndpoint(`/v1/cache`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheMetadata[]>;
+    }
+
+    /**
+     * Retrieves metadata for a single cached stream entry by stream ID.
+     * The cached design content is not exposed.
+     * @param streamId - ID of the stream
+     * @returns Cached stream metadata
+     */
+    async getStreamCache<R extends boolean = false>(streamId: string, raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheMetadata>> {
+        const resp = await this.axios.get<StreamCacheMetadata>(this.getEndpoint(`/v1/cache/${streamId}`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheMetadata>;
+    }
+
+    /**
+     * Deletes a single cached stream entry by stream ID.
+     * Does not interrupt currently running executions.
+     * @param streamId - ID of the stream cache entry to delete
+     */
+    async deleteStreamCache<R extends boolean = false>(streamId: string, raw?: { raw: R }): Promise<MaybeRaw<R, void>> {
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/cache/${streamId}`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, void>;
+    }
+
+    /**
+     * Deletes all cached stream entries.
+     * Does not interrupt currently running executions, future executions will rebuild the cache naturally.
+     * @returns Number of deleted cache entries
+     */
+    async clearCache<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheWipeResult>> {
+        const resp = await this.axios.delete<StreamCacheWipeResult>(this.getEndpoint(`/v1/cache`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheWipeResult>;
+    }
+
+    protected getEndpoint(endpoint: string): string {
+        return `${this.options.server}/api/agent${endpoint}`;
+    }
+}

--- a/src/lib/service/agent/index.ts
+++ b/src/lib/service/agent/index.ts
@@ -1,6 +1,7 @@
 import Base from "../../Base";
 import { AgentBundle } from "./bundle";
 import { DevBundle } from "./bundle/dev";
+import { AgentCache } from "./cache";
 import { AgentContext } from "./context";
 import { AgentInstaller } from "./installer";
 import { AgentLogging } from "./logging";
@@ -54,6 +55,14 @@ export default class Agent extends Base {
         return this._module;
     }
     private _module?: AgentModule;
+
+    public get cache(): AgentCache {
+        if (this._cache === undefined) {
+            this._cache = new AgentCache(this.options, this.axios);
+        }
+        return this._cache;
+    }
+    private _cache?: AgentCache;
 
     protected getEndpoint(endpoint: string): string {
         return `${this.options.server}/api/agent${endpoint}`;


### PR DESCRIPTION
Linked task: [HCLOUD-4698 Agent - Extend cached stream implementation](https://app.clickup.com/t/2570196/HCLOUD-4698).