### PR TITLE
HCLOUD-4809_attachAssetToStack-must-accept-an-array-of-new-assets-and-return-a-Stack_Artur-Grafov

### DIFF
--- a/.github/workflows/buildAndPublish.yml
+++ b/.github/workflows/buildAndPublish.yml
@@ -12,8 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.14.0]
-        pnpm-version: [11.7.0]
+        node-version: [24.18.0]
+        pnpm-version: [11]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/runLintAndBuild.yml
+++ b/.github/workflows/runLintAndBuild.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.14.0]
+        node-version: [24.18.0]
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.7.0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/src/lib/service/cosmo/stack/index.ts
+++ b/src/lib/service/cosmo/stack/index.ts
@@ -54,7 +54,7 @@ export class CosmoStack extends Base {
      * @param stackId ID of the Stack
      * @param assetIds Array of Asset IDs to detach
      * @param raw (optional) If true, returns the raw Axios response
-     * @returns The updated Stack
+     * @returns The updated Stack, or 204 No Content if the Stack is empty after detachment (disbanded)
      */
     async detachAssetsFromStack<R extends boolean = false>(
         organizationName: string,
@@ -62,12 +62,15 @@ export class CosmoStack extends Base {
         stackId: string,
         assetIds: string[],
         raw?: { raw: R }
-    ): Promise<MaybeRaw<R, Stack>> {
-        const resp = await this.axios.post<Stack>(this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/remove`), {
-            assetIds: assetIds,
-        });
+    ): Promise<MaybeRaw<R, Stack | undefined>> {
+        const resp = await this.axios.post<Stack>(
+            this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/remove`),
+            {
+                assetIds: assetIds,
+            }
+        );
 
-        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Stack>;
+        return (raw?.raw ? resp : resp.status === 200 ? resp.data : undefined) as MaybeRaw<R, Stack | undefined>;
     }
 
     /**

--- a/src/lib/service/cosmo/stack/index.ts
+++ b/src/lib/service/cosmo/stack/index.ts
@@ -23,25 +23,25 @@ export class CosmoStack extends Base {
     }
 
     /**
-     * Attach an Asset to an existing Stack in Cosmo.
+     * Attach Assets to an existing Stack in Cosmo.
      *
      * @param organizationName Name of the Organization
      * @param spaceName Name of the Space
      * @param stackId ID of the Stack
-     * @param assetId ID of the Asset to attach
+     * @param assetIds Array of Asset IDs to attach
      * @param raw (optional) If true, returns the raw Axios response
      * @returns The updated Stack
      */
-    async attachAssetToStack<R extends boolean = false>(
+    async attachAssetsToStack<R extends boolean = false>(
         organizationName: string,
         spaceName: string,
         stackId: string,
-        assetId: string,
+        assetIds: string[],
         raw?: { raw: R }
     ): Promise<MaybeRaw<R, Stack>> {
-        const resp = await this.axios.post<Stack>(
-            this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/${assetId}`)
-        );
+        const resp = await this.axios.post<Stack>(this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/add`), {
+            assetIds: assetIds,
+        });
 
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Stack>;
     }
@@ -52,20 +52,20 @@ export class CosmoStack extends Base {
      * @param organizationName Name of the Organization
      * @param spaceName Name of the Space
      * @param stackId ID of the Stack
-     * @param assetId ID of the Asset to detach
+     * @param assetIds Array of Asset IDs to detach
      * @param raw (optional) If true, returns the raw Axios response
      * @returns The updated Stack
      */
-    async detachAssetFromStack<R extends boolean = false>(
+    async detachAssetsFromStack<R extends boolean = false>(
         organizationName: string,
         spaceName: string,
         stackId: string,
-        assetId: string,
+        assetIds: string[],
         raw?: { raw: R }
     ): Promise<MaybeRaw<R, Stack>> {
-        const resp = await this.axios.delete<Stack>(
-            this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/${assetId}`)
-        );
+        const resp = await this.axios.post<Stack>(this.getEndpoint(`/v1/org/${organizationName}/spaces/${spaceName}/stacks/${stackId}/assets/remove`), {
+            assetIds: assetIds,
+        });
 
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Stack>;
     }


### PR DESCRIPTION
fix: add/remove assets to/from stack