### PR TITLE
HCLOUD-4699 Implement scheduled events using timestamp-to-Quartz conversion

### DIFF
--- a/src/lib/interfaces/high5/space/job/index.ts
+++ b/src/lib/interfaces/high5/space/job/index.ts
@@ -89,7 +89,9 @@ export interface Job {
 
 export type JobCreate = Pick<
     Job,
-    "name" | "expression" | "timezone" | "payload" | "enabled" | "description" | "target" | "lastStatus" | "lastTriggered" | "time"
+    "name" | "timezone" | "payload" | "enabled" | "description" | "target" | "lastStatus" | "lastTriggered" | "time"
 > & {
+    expression?: string;
+    timestamp?: string;
     targetEvent: string;
 };

--- a/src/lib/service/high5/space/event/index.ts
+++ b/src/lib/service/high5/space/event/index.ts
@@ -99,9 +99,13 @@ export class High5Event extends Base {
         orgName: string,
         spaceName: string,
         eventName: string,
+        options?: { deleteLinkedJobs: boolean },
         raw?: { raw: R }
     ): Promise<MaybeRaw<R, void>> {
-        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/events/${eventName}`));
+        const deleteLinkedJobs = options?.deleteLinkedJobs ? true : false;
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/org/${orgName}/spaces/${spaceName}/events/${eventName}`), {
+            params: { deleteLinkedJobs },
+        });
         return (raw?.raw ? resp : undefined) as MaybeRaw<R, void>;
     }
 


### PR DESCRIPTION
Linked task: [HCLOUD-4699 Implement scheduled events using timestamp-to-Quartz conversion](https://app.clickup.com/t/2570196/HCLOUD-4699).