### PR TITLE
HCLOUD-4803 Implement passkey login support

### DIFF
--- a/src/lib/helper/ValidationHelper.ts
+++ b/src/lib/helper/ValidationHelper.ts
@@ -51,6 +51,7 @@ enum Entity {
     TAG_COLOR = "TAG_COLOR",
     MODULE_NAME = "MODULE_NAME",
     LOG_COLLECTOR_NAME = "LOG_COLLECTOR_NAME",
+    PASSKEY_NAME = "PASSKEY_NAME",
 }
 
 interface Details {
@@ -396,6 +397,11 @@ const entityCollection: Record<Entity, Details> = {
         pattern: /^[\w-.]{1,64}$/i,
         minLength: 1,
         maxLength: 64,
+    },
+    [Entity.PASSKEY_NAME]: {
+        pattern: /^[\w-. ]{3,128}$/i,
+        minLength: 3,
+        maxLength: 128,
     },
 };
 

--- a/src/lib/interfaces/cosmo/share/index.ts
+++ b/src/lib/interfaces/cosmo/share/index.ts
@@ -1,4 +1,3 @@
-import { StorageConfiguration } from "../../global/Storage";
 import { ReducedUser, ShareReducedUnlinkedUser, User } from "../../idp";
 import { ItemType } from "../asset";
 

--- a/src/lib/interfaces/idp/index.ts
+++ b/src/lib/interfaces/idp/index.ts
@@ -9,6 +9,7 @@ export * from "./organization/settings/oauthApp";
 export * from "./organization/team";
 export * from "./user";
 export * from "./user/GeneralSettings";
+export * from "./user/Passkey";
 export * from "./user/Pat";
 export * from "./user/Scopes";
 export * from "./user/SuccessfulAuth";

--- a/src/lib/interfaces/idp/user/Passkey.ts
+++ b/src/lib/interfaces/idp/user/Passkey.ts
@@ -1,0 +1,159 @@
+/**
+ * Whether a passkey credential can be backed up and synced across multiple devices (e.g. via iCloud Keychain or
+ * Google Password Manager), or is bound to a single physical authenticator and cannot be synced
+ */
+export enum DeviceType {
+    SINGLE_DEVICE = "SINGLE_DEVICE",
+    MULTI_DEVICE = "MULTI_DEVICE",
+}
+
+/**
+ * How an authenticator is connected to the client device during a WebAuthn ceremony
+ */
+export enum AuthenticatorAttachment {
+    PLATFORM = "platform", // The authenticator is built into the client device (e.g. Touch ID, Windows Hello)
+    CROSS_PLATFORM = "cross-platform", // The authenticator is a removable/external device (e.g. a USB security key, or a phone reached via hybrid transport)
+}
+
+/**
+ * A transport an authenticator supports for communicating with the client device
+ */
+export enum AuthenticatorTransport {
+    BLE = "ble", // Bluetooth Low Energy
+    CABLE = "cable", // Cloud-assisted Bluetooth Low Energy (caBLE)
+    HYBRID = "hybrid", // A client device (e.g. a phone) reachable via QR code and BLE pairing
+    INTERNAL = "internal", // The authenticator is part of the client device itself (platform authenticator)
+    NFC = "nfc", // Near Field Communication
+    SMART_CARD = "smart-card", // Smart Card
+    USB = "usb", // USB
+}
+
+/**
+ * Public representation of a passkey registered by a user. Never includes the credential's public key or signature counter
+ */
+export interface Passkey {
+    credentialId: string; // Base64url-encoded credential ID
+    name: string; // User-friendly label for this passkey, e.g. "MacBook Touch ID"
+    deviceType?: DeviceType; // Whether the credential can be synced across multiple devices
+    createDate: number; // Creation date of the passkey, in milliseconds since the Unix epoch
+    lastUsedDate?: number; // Date the passkey was last used to log in, in milliseconds since the Unix epoch
+}
+
+/**
+ * The relying party a new passkey is being registered for
+ */
+export interface PasskeyRelyingParty {
+    id: string; // Domain identifying the relying party
+    name: string; // Human-readable name of the relying party shown to the user
+}
+
+/**
+ * The user a new passkey is being registered for
+ */
+export interface PasskeyUser {
+    id: string; // Opaque, base64url-encoded identifier for the user
+    name: string; // Username shown to help the user pick the right passkey
+    displayName: string; // Full display name shown alongside the passkey
+}
+
+/**
+ * References an existing credential, used to either exclude it from a new registration or allow it for authentication
+ */
+export interface PasskeyCredentialDescriptor {
+    id: string; // Base64url-encoded credential ID
+    transports?: AuthenticatorTransport[]; // Transports supported by this credential's authenticator
+}
+
+/**
+ * A public key algorithm accepted for a new credential
+ */
+export interface PasskeyPubKeyCredParam {
+    alg: number; // COSE algorithm identifier, e.g. -7 for ES256
+    type: "public-key"; // WebAuthn credential type, always "public-key"
+}
+
+/**
+ * Constraints the relying party places on which authenticators may be used and how they must behave during registration
+ */
+export interface PasskeyAuthenticatorSelection {
+    authenticatorAttachment?: AuthenticatorAttachment; // Preferred connection type for the authenticator, if the relying party wants to restrict it
+    residentKey?: string; // Whether the credential must be discoverable without the relying party specifying it beforehand
+    requireResidentKey?: boolean; // Legacy equivalent of requiring a discoverable credential, kept for older clients
+    userVerification?: string; // Whether the authenticator must verify the user's identity, for example via biometrics or a PIN
+}
+
+/**
+ * Options returned by the server to create a new passkey with an authenticator
+ */
+export interface PasskeyRegistrationOptions {
+    rp: PasskeyRelyingParty; // The relying party this passkey is being registered for
+    user: PasskeyUser; // The user this passkey is being registered for
+    challenge: string; // Random value the authenticator must sign to prove possession of the newly created private key
+    pubKeyCredParams: PasskeyPubKeyCredParam[]; // Public key algorithms accepted for the new credential, in order of preference
+    timeout?: number; // Maximum time in milliseconds the user has to complete the registration
+    excludeCredentials?: PasskeyCredentialDescriptor[]; // Credentials already registered for this user, so the authenticator can avoid creating a duplicate passkey for one of them
+    authenticatorSelection?: PasskeyAuthenticatorSelection; // Constraints on which authenticators may be used and how they must behave
+    attestation?: string; // Level of attestation statement requested from the authenticator about its provenance
+    extensions?: Record<string, unknown>; // Additional authenticator extension inputs, rarely used
+}
+
+/**
+ * Options returned by the server to authenticate with an existing passkey
+ */
+export interface PasskeyAuthenticationOptions {
+    challenge: string; // Random value the authenticator must sign to prove possession of the credential's private key
+    timeout?: number; // Maximum time in milliseconds the user has to complete the authentication
+    rpId?: string; // Domain identifying the relying party this passkey was registered for
+    allowCredentials?: PasskeyCredentialDescriptor[]; // Credentials allowed to complete this authentication. Intentionally omitted by the server so that any passkey registered for this relying party can be offered without knowing the user's identity beforehand
+    userVerification?: string; // Whether the authenticator must verify the user's identity, for example via biometrics or a PIN
+    extensions?: Record<string, unknown>; // Additional authenticator extension inputs, rarely used
+}
+
+/**
+ * The authenticator's response produced during passkey registration
+ */
+export interface PasskeyAttestationResponse {
+    clientDataJSON: string; // Base64url-encoded clientDataJSON, containing the ceremony type, challenge and origin
+    attestationObject: string; // Base64url-encoded CBOR attestationObject, containing the authenticator data and attestation statement
+    authenticatorData?: string; // Base64url-encoded authenticator data (optional convenience duplicate of the data already embedded in attestationObject)
+    transports?: AuthenticatorTransport[]; // Transports supported by this authenticator, as reported by the browser
+    publicKeyAlgorithm?: number; // COSE algorithm identifier used by the credential's public key
+    publicKey?: string; // Base64url-encoded DER SubjectPublicKeyInfo of the credential's public key
+}
+
+/**
+ * The credential produced by the browser during passkey registration (the value returned by `navigator.credentials.create()`),
+ * together with a label for the new passkey.
+ */
+export interface PasskeyRegistrationCredential {
+    id: string; // Base64url-encoded credential ID
+    rawId: string; // Base64url-encoded raw credential ID (identical to id)
+    response: PasskeyAttestationResponse; // The authenticator's attestation response
+    authenticatorAttachment?: AuthenticatorAttachment; // How the authenticator used for this registration is connected to the client device
+    clientExtensionResults: Record<string, unknown>; // Authenticator extension outputs returned by the browser (rarely used)
+    type: "public-key"; // WebAuthn credential type, always "public-key"
+    name: string; // User-friendly label for this passkey, e.g. "MacBook Touch ID"
+}
+
+/**
+ * The authenticator's response produced during passkey authentication
+ * (part of the value returned by `navigator.credentials.get()`)
+ */
+export interface PasskeyAssertionResponse {
+    clientDataJSON: string; // Base64url-encoded clientDataJSON, containing the ceremony type, challenge and origin
+    authenticatorData: string; // Base64url-encoded authenticator data, including the relying party ID hash, flags and signature counter
+    signature: string; // Base64url-encoded signature over the authenticator data and client data hash, produced with the credential's private key
+    userHandle?: string; // Base64url-encoded user handle (the userID set at registration), returned by the browser for discoverable credentials
+}
+
+/**
+ * The credential produced by the browser during passkey authentication (the value returned by `navigator.credentials.get()`)
+ */
+export interface PasskeyAuthenticationCredential {
+    id: string; // Base64url-encoded credential ID used to sign the challenge
+    rawId: string; // Base64url-encoded raw credential ID (identical to id)
+    response: PasskeyAssertionResponse; // The authenticator's assertion response
+    authenticatorAttachment?: AuthenticatorAttachment; // How the authenticator used for this login attempt is connected to the client device
+    clientExtensionResults: Record<string, unknown>; // Authenticator extension outputs returned by the browser (rarely used)
+    type: "public-key"; // WebAuthn credential type, always "public-key"
+}

--- a/src/lib/service/idp/index.ts
+++ b/src/lib/service/idp/index.ts
@@ -7,6 +7,7 @@ import { IdpGuest } from "./guest";
 import { IdpInternal } from "./internal";
 import { IdpOAuth } from "./oauth";
 import { IdpOrganization } from "./organization";
+import { IdpPasskey } from "./passkey";
 import { IdpRegistration } from "./registration";
 import { IdpUser } from "./user";
 
@@ -32,6 +33,17 @@ export default class Idp extends Base {
         return this._registration;
     }
     private _registration?: IdpRegistration;
+
+    /**
+     * Handles everything around passkey (WebAuthn) registration and login
+     */
+    public get passkey(): IdpPasskey {
+        if (this._passkey === undefined) {
+            this._passkey = new IdpPasskey(this.options, this.axios);
+        }
+        return this._passkey;
+    }
+    private _passkey?: IdpPasskey;
 
     /**
      * Handles everything around open authorization and openId requests

--- a/src/lib/service/idp/passkey.ts
+++ b/src/lib/service/idp/passkey.ts
@@ -1,0 +1,85 @@
+import Base, { MaybeRaw } from "../../Base";
+import {
+    Passkey,
+    PasskeyAuthenticationCredential,
+    PasskeyAuthenticationOptions,
+    PasskeyRegistrationCredential,
+    PasskeyRegistrationOptions,
+} from "../../interfaces/idp/user/Passkey";
+import { SuccessfulAuth } from "../../interfaces/idp/user/SuccessfulAuth";
+
+export class IdpPasskey extends Base {
+    /**
+     * Requests options for registering a new passkey for the currently authenticated user. Pass the returned object
+     * into `navigator.credentials.create()` to have the browser/authenticator create a new credential, then submit
+     * the result to {@link verifyRegistration}.
+     * @returns PasskeyRegistrationOptions object to be passed into `navigator.credentials.create()`
+     */
+    async createRegistrationOptions<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, PasskeyRegistrationOptions>> {
+        const resp = await this.axios.post<PasskeyRegistrationOptions>(this.getEndpoint("/v1/user/passkey/options"));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, PasskeyRegistrationOptions>;
+    }
+
+    /**
+     * Verifies a newly created passkey credential and, if valid, stores it for the currently authenticated user.
+     * @param credential The credential returned by `navigator.credentials.create()`, together with a user-friendly name for the passkey
+     * @returns The newly stored Passkey
+     */
+    async verifyRegistration<R extends boolean = false>(credential: PasskeyRegistrationCredential, raw?: { raw: R }): Promise<MaybeRaw<R, Passkey>> {
+        const resp = await this.axios.post<Passkey>(this.getEndpoint("/v1/user/passkey/verify"), credential);
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Passkey>;
+    }
+
+    /**
+     * Requests all passkeys registered for the currently authenticated user.
+     * @returns Array of Passkey objects
+     */
+    async getPasskeys<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, Passkey[]>> {
+        const resp = await this.axios.get<Passkey[]>(this.getEndpoint("/v1/user/passkey"));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, Passkey[]>;
+    }
+
+    /**
+     * Deletes a passkey registered for the currently authenticated user.
+     * @param credentialId Base64url-encoded credential ID of the passkey to delete
+     */
+    async deletePasskey<R extends boolean = false>(credentialId: string, raw?: { raw: R }): Promise<MaybeRaw<R, void>> {
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/user/passkey/${encodeURIComponent(credentialId)}`));
+        return (raw?.raw ? resp : undefined) as MaybeRaw<R, void>;
+    }
+
+    /**
+     * Requests options for logging in with a passkey. This endpoint requires no authentication and does not identify
+     * the user upfront - any passkey registered for this relying party may be used. Pass the returned object into
+     * `navigator.credentials.get()` to have the browser/authenticator produce an assertion, then submit the result
+     * to {@link verifyAuthentication}.
+     * @returns PasskeyAuthenticationOptions object to be passed into `navigator.credentials.get()`
+     */
+    async createAuthenticationOptions<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, PasskeyAuthenticationOptions>> {
+        const resp = await this.axios.post<PasskeyAuthenticationOptions>(this.getEndpoint("/v1/auth/passkey/options"));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, PasskeyAuthenticationOptions>;
+    }
+
+    /**
+     * Verifies a passkey authentication assertion. This endpoint requires no authentication. On success, the user is
+     * logged in and the response carries the Authorization header and auth_token cookie of the new session.
+     * @param credential The credential returned by `navigator.credentials.get()`
+     * @returns SuccessfulAuth object holding the token and the authenticated user
+     */
+    async verifyAuthentication<R extends boolean = false>(
+        credential: PasskeyAuthenticationCredential,
+        raw?: { raw: R }
+    ): Promise<MaybeRaw<R, SuccessfulAuth>> {
+        const resp = await this.axios.post(this.getEndpoint("/v1/auth/passkey/verify"), credential);
+
+        const authed: SuccessfulAuth = {
+            token: resp.headers["authorization"]?.toString() || "",
+            user: resp.data,
+        };
+        return (raw?.raw ? { ...resp, data: authed } : authed) as MaybeRaw<R, SuccessfulAuth>;
+    }
+
+    protected getEndpoint(endpoint: string): string {
+        return `${this.options.server}/api/account${endpoint}`;
+    }
+}


### PR DESCRIPTION
Linked task: [HCLOUD-4803 Backend: Passkeys - Implement passkey login support](https://app.clickup.com/t/2570196/HCLOUD-4803).