### PR TITLE
HCLOUD-4789 List and manage cached Wave Engines and node catalogs

### DIFF
--- a/src/lib/interfaces/agent/cache/catalog.ts
+++ b/src/lib/interfaces/agent/cache/catalog.ts
@@ -1,0 +1,6 @@
+export interface WaveCatalogMetadata {
+    version: string;
+    hash: string;
+    dev: boolean;
+    createDate: number;
+}

--- a/src/lib/interfaces/agent/cache/engine.ts
+++ b/src/lib/interfaces/agent/cache/engine.ts
@@ -1,0 +1,6 @@
+export interface WaveEngineMetadata {
+    version: string;
+    hash: string;
+    dev: boolean;
+    createDate: number;
+}

--- a/src/lib/interfaces/agent/cache/index.ts
+++ b/src/lib/interfaces/agent/cache/index.ts
@@ -1,3 +1,6 @@
+export * from "./catalog";
+export * from "./engine";
+
 export interface StreamCacheMetadata {
     streamId: string;
     orgName: string;

--- a/src/lib/service/agent/cache/index.ts
+++ b/src/lib/service/agent/cache/index.ts
@@ -1,5 +1,5 @@
 import Base, { MaybeRaw } from "../../../Base";
-import { StreamCacheMetadata, StreamCacheWipeResult } from "../../../interfaces/agent/cache";
+import { StreamCacheMetadata, StreamCacheWipeResult, WaveCatalogMetadata, WaveEngineMetadata } from "../../../interfaces/agent/cache";
 
 export class AgentCache extends Base {
     /**
@@ -8,7 +8,7 @@ export class AgentCache extends Base {
      * @returns Array of cached stream metadata
      */
     async listStreamCache<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheMetadata[]>> {
-        const resp = await this.axios.get<StreamCacheMetadata[]>(this.getEndpoint(`/v1/cache`));
+        const resp = await this.axios.get<StreamCacheMetadata[]>(this.getEndpoint(`/v1/cache/streams`));
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheMetadata[]>;
     }
 
@@ -19,7 +19,7 @@ export class AgentCache extends Base {
      * @returns Cached stream metadata
      */
     async getStreamCache<R extends boolean = false>(streamId: string, raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheMetadata>> {
-        const resp = await this.axios.get<StreamCacheMetadata>(this.getEndpoint(`/v1/cache/${streamId}`));
+        const resp = await this.axios.get<StreamCacheMetadata>(this.getEndpoint(`/v1/cache/streams/${streamId}`));
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheMetadata>;
     }
 
@@ -29,7 +29,7 @@ export class AgentCache extends Base {
      * @param streamId - ID of the stream cache entry to delete
      */
     async deleteStreamCache<R extends boolean = false>(streamId: string, raw?: { raw: R }): Promise<MaybeRaw<R, void>> {
-        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/cache/${streamId}`));
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/cache/streams/${streamId}`));
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, void>;
     }
 
@@ -39,8 +39,44 @@ export class AgentCache extends Base {
      * @returns Number of deleted cache entries
      */
     async clearCache<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, StreamCacheWipeResult>> {
-        const resp = await this.axios.delete<StreamCacheWipeResult>(this.getEndpoint(`/v1/cache`));
+        const resp = await this.axios.delete<StreamCacheWipeResult>(this.getEndpoint(`/v1/cache/streams`));
         return (raw?.raw ? resp : resp.data) as MaybeRaw<R, StreamCacheWipeResult>;
+    }
+
+    /**
+     * Retrieves metadata for all Wave Engine versions currently cached on the agent.
+     * @returns Array of cached Wave Engine metadata
+     */
+    async listEngines<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, WaveEngineMetadata[]>> {
+        const resp = await this.axios.get<WaveEngineMetadata[]>(this.getEndpoint(`/v1/cache/engines`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, WaveEngineMetadata[]>;
+    }
+
+    /**
+     * Deletes a cached Wave Engine version from the agent.
+     * @param version - Version of the cached Wave Engine to remove
+     */
+    async deleteEngine<R extends boolean = false>(version: string, raw?: { raw: R }): Promise<MaybeRaw<R, void>> {
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/cache/engines/${version}`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, void>;
+    }
+
+    /**
+     * Retrieves metadata for all Wave Catalogs currently cached on the agent.
+     * @returns Array of cached Wave Catalog metadata
+     */
+    async listCatalogs<R extends boolean = false>(raw?: { raw: R }): Promise<MaybeRaw<R, WaveCatalogMetadata[]>> {
+        const resp = await this.axios.get<WaveCatalogMetadata[]>(this.getEndpoint(`/v1/cache/catalogs`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, WaveCatalogMetadata[]>;
+    }
+
+    /**
+     * Deletes a cached Wave Catalog from the agent.
+     * @param hash - MD5 hash (of url + version) of the cached Wave Catalog to remove
+     */
+    async deleteCatalog<R extends boolean = false>(hash: string, raw?: { raw: R }): Promise<MaybeRaw<R, void>> {
+        const resp = await this.axios.delete<void>(this.getEndpoint(`/v1/cache/catalogs/${hash}`));
+        return (raw?.raw ? resp : resp.data) as MaybeRaw<R, void>;
     }
 
     protected getEndpoint(endpoint: string): string {


### PR DESCRIPTION
Linked task: [HCLOUD-4789 Agent API: List and manage cached Wave Engines and node catalogs](https://app.clickup.com/t/2570196/HCLOUD-4789).