### PR TITLE
HCLOUD-4943_backends-must-reconnect-to-nats-on-disconnect_Artur-Grafov

### DIFF
--- a/src/lib/service/nats/index.ts
+++ b/src/lib/service/nats/index.ts
@@ -71,6 +71,7 @@ class Nats extends Base {
         this.natsConnection = await this.connection({
             debug: params.debug,
             maxReconnectAttempts: -1,
+            ignoreAuthErrorAbort: true,
             servers: params.servers,
             pingInterval: 55 * 1000, //ping every 55 seconds
             user: (params as ConnectParamsJwt).email !== undefined ? (params as ConnectParamsJwt).email : (params as ConnectParamsPassword).username,
@@ -82,8 +83,6 @@ class Nats extends Base {
                 entry.sub.callback?.(err as NatsError, msg ? msg : ({} as Msg));
             });
         }
-
-        this.natsConnection.reconnect();
 
         return this.natsConnection;
     }


### PR DESCRIPTION
fix: backends nats reconnect
    
    Remove reconnect statement, as reconnect is automatically switched on:
        /**
         * When set to true, the server will attempt to reconnect so long as
         * {@link maxReconnectAttempts} doesn't prevent it.
         * @default true <--
         */
        reconnect?: boolean;
    
    Also add parameter to avoid infinite reconnect to stop in case of auth errors:
    /**
         * By default, NATS clients will abort reconnect if they fail authentication
         * twice in a row with the same error, regardless of the reconnect policy.
         * This option should be used with care as it will disable this behaviour when true
         */
        ignoreAuthErrorAbort?: boolean;

